### PR TITLE
build: switch to nodenext + skipLibCheck

### DIFF
--- a/src/eiscp/config.ts
+++ b/src/eiscp/config.ts
@@ -1,5 +1,5 @@
-import { PlatformConfig } from 'homebridge';
-import { ReceiverConfig } from '../receiverConfig';
+import type { PlatformConfig } from 'homebridge';
+import type { ReceiverConfig } from '../receiverConfig.js';
 
 export interface Config extends PlatformConfig {
   receivers: ReceiverConfig[];

--- a/src/eiscp/eiscp.ts
+++ b/src/eiscp/eiscp.ts
@@ -4,7 +4,6 @@ import async from 'async';
 import util from 'util';
 
 import { EventEmitter } from 'events';
-// @ts-expect-error need to import json file
 import eiscp_commands from './eiscp-commands.json' with { type: 'json' };
 import { Logger } from 'homebridge';
 

--- a/src/onkyoReceiver.ts
+++ b/src/onkyoReceiver.ts
@@ -4,7 +4,6 @@ import { Eiscp } from './eiscp/eiscp.js';
 import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { ReceiverInputConfig } from './receiverInputConfig.js';
 import pollingtoevent from 'polling-to-event';
-// @ts-expect-error need to import json
 import eiscpDataAll from './eiscp/eiscp-commands.json' with { type: 'json' };
 import { PLUGIN_NAME } from './settings.js';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "lib": ["ES2022"],
-    "module": "ES2022",
+    "module": "nodenext",
     "target": "ES2022",
     "rootDir": "src",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "strict": true,
     "declaration": true,
     "outDir": "dist",
@@ -14,7 +14,8 @@
     "esModuleInterop": true,
     "noImplicitAny": false,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "include": [".eslintrc.json", "homebridge-ui", "src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
Mirror the same tsconfig hardening landed in `homebridge-philips-hue-sync-box` (#378, #379) preemptively, before homebridge 2.x's `@matter/*` transitive deps cause the same CI failure here.

## Changes
- `tsconfig.json`: `moduleResolution: "node"` → `"nodenext"`, `module: "ES2022"` → `"nodenext"`, add `skipLibCheck: true`.
- `src/eiscp/config.ts`: `import { PlatformConfig } from 'homebridge'` and `import { ReceiverConfig } from '../receiverConfig'` → `import type ... from '...js'`. Both are type-only usages; classic `node` resolution silently accepted the missing extension because the imports were erased at emit.
- `src/eiscp/eiscp.ts` and `src/onkyoReceiver.ts`: removed two now-unused `@ts-expect-error` directives over `import ... with { type: 'json' }` imports. `nodenext` + `resolveJsonModule: true` supports JSON import attributes natively, so the suppressions are no longer needed (tsc was flagging them as unused).

## Why
- Classic `moduleResolution: "node"` doesn't model Node's `package.json` `imports`/`exports`, so tsc and Node disagree about how to resolve deps. For an ESM project (`"type": "module"`) this mismatch is a footgun.
- `nodenext` matches Node's runtime behavior. `module: "nodenext"` is the conventional pairing. `skipLibCheck` defends against unrelated upstream `.d.ts` rot (it's not a substitute for `nodenext` — they fix different problems).

## Verification
- `npm run build` (clean → compile) passes.
- `npm run lint` passes.

## Test plan
- [ ] CI passes on this PR
- [ ] Smoke test the plugin against a real Onkyo receiver + homebridge instance to confirm no runtime regression from `module: "nodenext"` (CJS/ESM interop semantics differ slightly from `module: "ES2022"`)