### PR TITLE
fix: preserve reconnect context

### DIFF
--- a/src/eiscp/eiscp.ts
+++ b/src/eiscp/eiscp.ts
@@ -541,7 +541,7 @@ export class Eiscp extends EventEmitter {
         this.emit('close', this.config.host, this.config.port);
 
         if (this.config.reconnect) {
-          setTimeout(this.connect, this.config.reconnect_sleep * 1000);
+          setTimeout(() => this.connect(), this.config.reconnect_sleep * 1000);
         }
       })
       .on('error', err => {


### PR DESCRIPTION
Summary
- Fixes the reconnect timer so it calls `connect()` with the `Eiscp` instance context intact.
- Prevents the reconnect path from passing `this.connect` as an unbound callback, which can make `this` undefined when the timer fires.
- Keeps the change limited to the reconnect scheduling line in `src/eiscp/eiscp.ts`.

Validation
- `npm ci` passed, with existing engine/audit warnings. Local Node is `v22.13.1`; the package declares `node: ^24.0.0`.
- `npm install` passed, with the same existing engine/audit warnings.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run build` passed.
- `git diff --check` passed.
- `npm test` failed before linting source files because XO/ESLint rejected the existing `@stylistic/indent` rule configuration: `Expected severity of "off", 0, "warn", 1, "error", or 2`.
- `npm run prettier` failed on existing formatting differences across 37 files, including templates, config files, README, and source files. I left those unrelated files unchanged to keep this PR small.

Notes
- Resolves #177.
- No dependency or lockfile changes are included.
- No compatibility impact is expected beyond preserving the intended reconnect behavior.
