### PR TITLE
fix: eISCP UDP discovery crash + dependency pinning cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,8 @@
       "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
-        "async": "*",
-        "js-yaml": "*",
-        "polling-to-event": "^2.1.0",
-        "utils": "^0.3.1"
+        "async": "^3.2.6",
+        "polling-to-event": "^2.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "21.2.1",
@@ -41,6 +39,7 @@
         "homebridge": "2.1.1",
         "homebridge-config-ui-x": "5.24.0",
         "husky": "9.1.7",
+        "js-yaml": "^4.2.0",
         "lint-staged": "17.0.8",
         "nodemon": "3.1.14",
         "npm-run-all2": "9.0.2",
@@ -3967,32 +3966,6 @@
         }
       }
     },
-    "node_modules/align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/align-text/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -4035,19 +4008,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/any": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/any/-/any-1.0.0.tgz",
-      "integrity": "sha512-eHlqaTpbeFyxHAo2H8XI566tY/m+lvRUTsFwBNtWP08qJe7bf16Oj5ab2coiuY9yTMvzFgjpWbuqQIFqH+yi+w==",
-      "license": "MIT",
-      "dependencies": {
-        "for-own": "^0.1.2",
-        "make-iterator": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -4055,17 +4015,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/any/node_modules/make-iterator": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.1.1.tgz",
-      "integrity": "sha512-s8tbTxYqrfcXYHAPxUecPxgBnWod7yFShdSOWiV17WRM87bBH2mzr24A4tpUDv9SqebaV6JsPApwKXnisMmMBA==",
-      "dependencies": {
-        "for-own": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -4115,6 +4064,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/argue-cli": {
@@ -4138,103 +4088,12 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/arr-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-      "integrity": "sha512-OQwDZUqYaQwyyhDJHThmzId8daf4/RFNLaeh3AevmSeZ5Y7ug4Ga/yKc6l6kTZOBW781rCj103ZuTh8GAsB3+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-flatten": "^1.0.1",
-        "array-slice": "^0.2.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/arr-map/-/arr-map-2.0.2.tgz",
-      "integrity": "sha512-tVqVTHt+Q5Xb09qRkbu+DidW1yYzz5izWS2Xm2yFm7qJnmUfz4HPzNxbHkdRJbz2lrqI7S+z17xNYdFcBBO8Hw==",
-      "license": "MIT",
-      "dependencies": {
-        "make-iterator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-map/node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-map/node_modules/make-iterator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
-      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-each": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/array-each/-/array-each-0.1.1.tgz",
-      "integrity": "sha512-UeLKGl1CO9AS8+y+d+sCoI4PEFcphx0fGlPiOgzlYAmofYov5fpqvqZdTEk11nXV2E6a6WtepT2gEB0RL2fnmg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/array-slice": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "integrity": "sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/arrify": {
       "version": "3.0.0",
@@ -4655,19 +4514,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
-      "license": "MIT",
-      "dependencies": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/chalk": {
@@ -7297,27 +7143,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/export-dirs": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/export-dirs/-/export-dirs-0.2.4.tgz",
-      "integrity": "sha512-fBQ2iiw2FPxyzsOOVpWICXUNbuSBanxYYyDy1gaF4Gpfp7UkiuPA6N57Daqf7FpFDyT3g1+L+Rz4tr4aRj9SRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/export-files": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
-      "integrity": "sha512-r2x1Zt0OKgdXRy0bXis3sOI8TNYmo5Fe71qXwsvpYaMvIlH5G0fWEf3AYiE2bONjePdSOojca7Jw+p9CQ6/6NQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lazy-cache": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/extend": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
@@ -7732,36 +7557,6 @@
         "debug": {
           "optional": true
         }
-      }
-    },
-    "node_modules/for-in": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-      "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
-      "license": "MIT",
-      "dependencies": {
-        "for-in": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/for-own/node_modules/for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/form-data": {
@@ -8242,15 +8037,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-values": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-      "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/hasown": {
@@ -8772,12 +8558,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
-    },
     "node_modules/is-builtin-module": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
@@ -8818,15 +8598,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -8976,18 +8747,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
@@ -9066,15 +8825,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/issue-parser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
@@ -9133,6 +8883,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9341,27 +9092,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-      "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/levn": {
@@ -9765,15 +9495,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -9843,30 +9564,6 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/make-iterator": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.2.1.tgz",
-      "integrity": "sha512-YJMm/IuF0mj/mGPqyw6gbJ3WZCSCTd+1Y1Z1+bqZFjYNZHRXF+CQGTUxE7A65y/iAONUA42BOiJ5cEt4AZpfVg==",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/make-iterator/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/map-stream": {
       "version": "0.0.7",
@@ -13377,90 +13074,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/object.defaults": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-0.3.0.tgz",
-      "integrity": "sha512-VOrsFahJiyB6ajWr5z0C8+mFY47WtWn2w5VFkJHjluy28fg22m2yFZDxu3EmKtf4x38GHFjvmRtPx0aQgTTmQg==",
-      "license": "MIT",
-      "dependencies": {
-        "array-each": "^0.1.0",
-        "array-slice": "^0.2.3",
-        "for-own": "^0.1.3",
-        "isobject": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.defaults/node_modules/isobject": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-      "integrity": "sha512-WQQgFoML/sLgmhu9zTekYHZUJaPoa/fpVMQ8oxIuOvppzs70DxxyHZdAIjwcuuNDOVtNYsahhqtBbUvKwhRcGw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.filter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/object.filter/-/object.filter-0.3.0.tgz",
-      "integrity": "sha512-f/OJtvg2H7ZykQpcCbKTSucLhz9+7pmgJzrI3gPaelCkjkg9Pd+moFN2DFDfx/IWS5f/sMeSqe3xXNnb0MV4DQ==",
-      "dependencies": {
-        "for-own": "^0.1.2",
-        "make-iterator": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.filter/node_modules/make-iterator": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-0.1.1.tgz",
-      "integrity": "sha512-s8tbTxYqrfcXYHAPxUecPxgBnWod7yFShdSOWiV17WRM87bBH2mzr24A4tpUDv9SqebaV6JsPApwKXnisMmMBA==",
-      "dependencies": {
-        "for-own": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
-      "license": "MIT",
-      "dependencies": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.pick": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.reduce": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/object.reduce/-/object.reduce-0.1.7.tgz",
-      "integrity": "sha512-5PMRmWAfIbCJavx9xETLSjr0IvHHDOjhW9jnHkOmnTC0Q4d9tWM5GjBAPS+J4yLk2Q+ql/XJBBbBOp2xTzDhDg==",
-      "license": "MIT",
-      "dependencies": {
-        "for-own": "^0.1.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -14748,15 +14361,6 @@
         "regjsparser": "bin/parser"
       }
     },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -14855,18 +14459,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
-      "license": "MIT",
-      "dependencies": {
-        "align-text": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/rimraf": {
       "version": "6.1.3",
@@ -15800,12 +15392,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/striptags": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
-      "integrity": "sha512-vZTvmFP0IYu/zn8MXV6PrLb6VKbd9WGSEnlm4D5RNXS/+zYYlHrSfJgoBw1w56D6RJCr515er3BittRGQqihLA==",
-      "license": "MIT"
     },
     "node_modules/strtok3": {
       "version": "10.3.5",
@@ -16818,43 +16404,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/utils/-/utils-0.3.1.tgz",
-      "integrity": "sha512-MQui5t13wIAkllcVSR/19WTvLxfJRKHwlLmBin3iqJ1F1kFMZtValrOwwn0Ez43bOQwCNhzJAjOoX74UkVI+Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "any": "^1.0.0",
-        "arr-diff": "^1.1.0",
-        "arr-flatten": "^1.0.1",
-        "arr-map": "^2.0.0",
-        "arr-union": "^3.0.0",
-        "array-each": "^0.1.1",
-        "array-slice": "^0.2.3",
-        "array-unique": "^0.2.1",
-        "center-align": "^0.1.1",
-        "export-dirs": "^0.2.4",
-        "export-files": "^2.1.0",
-        "for-in": "^0.1.4",
-        "for-own": "^0.1.3",
-        "has-values": "^0.1.3",
-        "is-number": "^2.0.2",
-        "is-plain-object": "^2.0.1",
-        "kind-of": "^2.0.1",
-        "make-iterator": "^0.2.0",
-        "object.defaults": "^0.3.0",
-        "object.filter": "^0.3.0",
-        "object.omit": "^2.0.0",
-        "object.pick": "^1.1.1",
-        "object.reduce": "^0.1.7",
-        "right-align": "^0.1.3",
-        "striptags": "^2.0.3",
-        "word-wrap": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -16863,30 +16412,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/utils/node_modules/is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/utils/node_modules/is-number/node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -17009,6 +16534,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint": "10.7.0",
         "eslint-plugin-ava": "17.0.1",
         "eslint-plugin-json": "4.0.1",
-        "eslint-plugin-unicorn": "latest",
+        "eslint-plugin-unicorn": "^71.1.0",
         "homebridge": "2.1.1",
         "homebridge-config-ui-x": "5.24.0",
         "husky": "9.1.7",

--- a/package.json
+++ b/package.json
@@ -91,10 +91,8 @@
     "space": false
   },
   "dependencies": {
-    "async": "*",
-    "js-yaml": "*",
-    "polling-to-event": "^2.1.0",
-    "utils": "^0.3.1"
+    "async": "^3.2.6",
+    "polling-to-event": "^2.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "21.2.1",
@@ -123,6 +121,7 @@
     "homebridge": "2.1.1",
     "homebridge-config-ui-x": "5.24.0",
     "husky": "9.1.7",
+    "js-yaml": "^4.2.0",
     "lint-staged": "17.0.8",
     "nodemon": "3.1.14",
     "npm-run-all2": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -53,10 +53,11 @@
   },
   "xo": {
     "ignores": "eiscp",
+    "files": "**/*.ts",
     "rules": {
       "unicorn/prefer-module": "warn",
       "unicorn/no-new-array": "warn",
-      "unicorn/no-array-for-each": "warn",
+      "unicorn/no-for-each": "warn",
       "camelcase": "off",
       "kebabCase": "off",
       "no-mixed-spaces-and-tabs": "warn",
@@ -117,7 +118,7 @@
     "eslint": "10.7.0",
     "eslint-plugin-ava": "17.0.1",
     "eslint-plugin-json": "4.0.1",
-    "eslint-plugin-unicorn": "latest",
+    "eslint-plugin-unicorn": "^71.1.0",
     "homebridge": "2.1.1",
     "homebridge-config-ui-x": "5.24.0",
     "husky": "9.1.7",

--- a/src/eiscp/eiscp.ts
+++ b/src/eiscp/eiscp.ts
@@ -376,6 +376,19 @@ export class Eiscp extends EventEmitter {
         let data;
         if (command === 'ECN') {
           data = message.slice(3).split('/');
+          if (data.length < 4) {
+            this.emit(
+              'debug',
+              util.format(
+                'DEBUG (received_discovery) Ignored malformed discovery reply from %s:%s - %j',
+                rinfo.address,
+                rinfo.port,
+                message
+              )
+            );
+            return;
+          }
+
           result.push({
             host: rinfo.address,
             port: data[1],

--- a/src/eiscp/examples/1.ts
+++ b/src/eiscp/examples/1.ts
@@ -1,11 +1,9 @@
 /* eslint-disable no-console */
-import util from 'utils';
-
 import { Eiscp } from '../eiscp.js';
 const eiscp = new Eiscp(console);
 
-eiscp.on('debug', util.log);
-eiscp.on('error', util.log);
+eiscp.on('debug', console.log);
+eiscp.on('error', console.log);
 
 // Discover receviers on network, stop after 2 receviers or 5 seconds
 


### PR DESCRIPTION
## Summary
Fixes that came out of a security review of this repo:

- **`fix(eiscp)`** — `Eiscp.discover()`'s UDP `'message'` handler indexed into `data[3]` (from `message.slice(3).split('/')`) without checking the array length first. A discovery reply with fewer than 4 `/`-delimited fields left `data[3]` `undefined`, and `.slice(0,12)` on it threw synchronously with nothing in the call chain to catch it — any malformed UDP reply reaching the ephemeral discovery socket (e.g. from a misbehaving or malicious device on the same broadcast domain, when `discover()` runs because `ip_address`/`model` is left blank in config) could crash the whole Homebridge process, not just this plugin's accessories. Now it logs and ignores the malformed reply instead.

- **`chore(deps)`** — `async` and `js-yaml` were pinned to the unconstrained `"*"` range, so every install silently took whatever those packages' latest publish happened to be at install time (no protection if either were ever compromised, à la `event-stream`/`ua-parser-js`/the 2025 `chalk`/`debug` incidents). `async` is now pinned to `^3.2.6`. `js-yaml` has no runtime consumer (its only reference is the build-time `eiscp-commands-convert.ts` script, which isn't wired into any npm script or CI job) and moves to `devDependencies` pinned to `^4.2.0`. `utils` is dropped entirely — its only consumer was the debug logger in `src/eiscp/examples/1.ts` (now uses `console.log` like the other examples), and it was pulling in a moderate-severity, no-fix-available transitive vulnerability (`striptags`, GHSA-qxg5-2qff-p49r) for zero functional benefit. `npm audit --omit=dev` goes from 2 moderate findings to 0.

- **`fix(deps)`** — `eslint-plugin-unicorn` was also pinned to the bare `"latest"` tag (same unconstrained-version issue as above). It had resolved to `71.1.0`, which renamed the `unicorn/no-array-for-each` rule to `unicorn/no-for-each`; the old name referenced in this repo's `xo` config made `npm test` crash outright (`Could not find "no-array-for-each" in plugin "unicorn"`) instead of linting anything. Pinned to `^71.1.0` and updated the rule name. Also scoped the `xo` config's custom `rules` block to `**/*.ts` via `files`, since without it those rules were being merged into every language `xo` lints — including markdown's `gfm` virtual language, where they don't apply and caused a second, different hard crash.

## ⚠️ Follow-up needed (separate from this PR)
With the crash fixed, `npm test` (`xo`) now runs to completion and reports **~3,170 pre-existing lint findings** across `src/**/*.ts`, `README.md`, `CHANGELOG.md`, `commitlint.config.js`, and the GitHub issue templates. This traces back to `chore(deps): update dependency xo to v4 (#225)`, an earlier Renovate merge — XO v4 lints Markdown/JSON by default now and changed several core style rules (tabs vs. spaces, `interface` vs `type`, etc.), none of which this repo's code or docs currently conform to. `npm test` has likely been silently broken since #225 merged; the crash just masked it until now.

I did **not** attempt to fix these — `xo --fix` rewrites the entire `src/eiscp/` folder stylistically (1,250+ line diff on `eiscp.ts` alone), which `AGENTS.md` explicitly says to avoid ("treat this folder as third-party... avoid stylistic refactors"), plus it touches unrelated docs. This needs a deliberate decision — e.g. downgrade `xo` back to a compatible major, or do a scoped/reviewed mass-reformat — rather than a drive-by autofix bundled into a security-fix PR.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm audit --omit=dev` → 0 vulnerabilities (was 2 moderate via `utils`→`striptags`)
- [x] `npm test` (`xo`) no longer crashes (was: hard `TypeError` on a clean install)
- [ ] `npm test` is still failing on ~3,170 pre-existing findings — see follow-up note above