### PR TITLE
fix(release): restore changelog bodies by pinning conventionalcommits to v9

### DIFF
--- a/.github/workflows/pr-license-comment.yml
+++ b/.github/workflows/pr-license-comment.yml
@@ -25,7 +25,7 @@ on:
       - completed
 
 permissions:
-  actions: read           # download-artifact run-id mode (cross-run) needs this
+  actions: read # download-artifact run-id mode (cross-run) needs this
   contents: read
   id-token: write
   pull-requests: write

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 package-lock.json
 CHANGELOG.md
+sbom.cdx.json

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 ## WARNING: This plugin is not actively maintained except for automated dependency updates. Issues/bugs are unlikely to be addressed. Use at your own risk
 
-
 Homebridge plugin for Onkyo Receivers
 Should work for all supported models as listed in the eiscp/eiscp-commands.json file. If your model is not listed, try TX-NR609.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@types/node": "24.13.3",
         "@typescript-eslint/eslint-plugin": "8.64.0",
         "@typescript-eslint/parser": "8.64.0",
-        "conventional-changelog-conventionalcommits": "10.2.1",
+        "conventional-changelog-conventionalcommits": "9.3.1",
         "cross-env": "10.1.0",
         "eslint": "10.7.0",
         "eslint-plugin-ava": "17.0.1",
@@ -187,6 +187,19 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -5189,16 +5202,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@types/node": "24.13.3",
     "@typescript-eslint/eslint-plugin": "8.64.0",
     "@typescript-eslint/parser": "8.64.0",
-    "conventional-changelog-conventionalcommits": "10.2.1",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "cross-env": "10.1.0",
     "eslint": "10.7.0",
     "eslint-plugin-ava": "17.0.1",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jabrown93/.github//renovate-config.json"]
+  "extends": ["github>jabrown93/.github//renovate-config.json"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["conventional-changelog-conventionalcommits"],
+      "allowedVersions": "<10.0.0",
+      "description": "Pinned to v9: v10 builds writerOpts from @conventional-changelog/template JS functions that require conventional-changelog-writer v9, but @semantic-release/release-notes-generator pins conventional-changelog-writer ^8 and silently ignores them, producing heading-only CHANGELOG entries with no commit bodies. Unpin once release-notes-generator supports writer v9."
+    }
+  ]
 }


### PR DESCRIPTION
## Problem

`1.5.2` shipped a **heading-only** CHANGELOG entry:

```
## [1.5.2](.../compare/v1.5.1...v1.5.2) (2026-07-16)

## [1.5.1](.../compare/v1.5.0...v1.5.1) (2026-06-17)
```

`1.5.1` (2026-06-17) was the last release with a body.

## Root cause

`conventional-changelog-conventionalcommits` **v10** builds its `writerOpts` from `@conventional-changelog/template` JS functions, which require `conventional-changelog-writer` **v9**. `@semantic-release/release-notes-generator@14.1.1` (latest) pins `conventional-changelog-writer@^8`, which cannot consume them — it silently discards the preset's `template`/`transform`, falls back to its own default header template (`## [{{version}}]({{compareUrlFormat}}) ({{date}})` — exactly the stub), and drops every commit.

Nothing errors, which is why this looked like a flake.

## Verification

Replayed the real `@semantic-release/release-notes-generator` against the real `v1.5.1..v1.5.2` range (41 commits):

| Preset | Result |
|---|---|
| **10.2.1** | heading-only — the stub that shipped |
| **9.3.1** | `### Bug Fixes` + `* eISCP UDP discovery crash + dependency pinning cleanup (#230)` ✅ |

## Changes

- Pin `conventional-changelog-conventionalcommits` to `9.3.1`. `@commitlint/config-conventional` requires `^10.0.0` and resolves its own nested v10; it only uses the parser, so it is unaffected.
- Renovate rule blocking v10 until `release-notes-generator` supports writer v9. Renovate introduced this, so without the rule it regresses silently.
- Ignore the generated `sbom.cdx.json` in `.prettierignore` — `.releaserc.json` generates it during `prepare`, and `prepublishOnly` runs `prettier --check .`, so the generated SBOM can fail the publish.
- Repo-wide `prettier --write .`. Note `.github/workflows/pr-license-comment.yml` was **already unformatted** and would have failed that same `prettier --check` on the next release. All source changes are formatting-only (`git diff -w` is empty).

There is no upstream fix to wait for — `release-notes-generator@14.1.1` is the latest and still pins writer `^8`.