### PR TITLE
docs(changelog): backfill 1.5.2 entry body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file. See
 
 ## [1.5.2](https://github.com/jabrown93/homebridge-onkyo/compare/v1.5.1...v1.5.2) (2026-07-16)
 
+### Bug Fixes
+
+* eISCP UDP discovery crash + dependency pinning cleanup ([#230](https://github.com/jabrown93/homebridge-onkyo/issues/230)) ([925128c](https://github.com/jabrown93/homebridge-onkyo/commit/925128cd1e1dd37d86b910fdce11468fd06c0c2e))
+
 ## [1.5.1](https://github.com/jabrown93/homebridge-onkyo/compare/v1.5.0...v1.5.1) (2026-06-17)
 
 ### Bug Fixes


### PR DESCRIPTION
## What

Fills in the body of the `1.5.2` CHANGELOG entry, which shipped as a heading with nothing under it:

```markdown
## [1.5.2](https://github.com/jabrown93/homebridge-onkyo/compare/v1.5.1...v1.5.2) (2026-07-16)

## [1.5.1](...) (2026-06-17)
```

## Why

`1.5.2` released while `conventional-changelog-conventionalcommits` v10 was installed. v10 builds `writerOpts` from `@conventional-changelog/template` JS functions that require `conventional-changelog-writer` v9, but `@semantic-release/release-notes-generator@14.1.1` pins writer `^8` and silently ignores them — so `generateNotes` returned a heading and dropped every commit, with no error. #234 pinned the preset back to v9, which is why `1.5.3` and `1.5.4` have proper bodies. This is the one stub entry left behind.

## How

Regenerated by calling the real `generateNotes` with the now-pinned v9 preset against the actual `v1.5.1..v1.5.2` commit range, using this repo's `.releaserc.json` options. Output:

```
* eISCP UDP discovery crash + dependency pinning cleanup ([#230](...)) ([925128c](...))
```

Of the 41 commits in the range, #230 is the only release-worthy one; the other 40 are `chore(deps)`, which the conventionalcommits preset hides. The original release date (2026-07-16) is preserved — only the body was added.

Docs-only. No source, config, or dependency changes.