### PR TITLE
ci: migrate shared CI to jabrown93/ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,14 @@ on:
   - pull_request
 jobs:
   build:
-    uses: jabrown93/.github/.github/workflows/node-build.yml@71c3af9fc09ce87b086cc058773380acaf2b1299 # v1.2.0
-    with:
-      node-versions: '["22.x", "24.x"]'
+    # node-build is now a composite action, so the caller owns the matrix and
+    # runs-on (a composite action cannot declare either).
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22.x', '24.x']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jabrown93/ci/actions/node-build@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # node-build-v1.0.0
+        with:
+          node-version: ${{ matrix.node-version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,9 +9,14 @@ on:
     - cron: '25 22 * * 5'
 jobs:
   analyze:
-    uses: jabrown93/.github/.github/workflows/codeql.yml@71c3af9fc09ce87b086cc058773380acaf2b1299 # v1.2.0
+    # codeql is now a composite action, so the caller owns runs-on and MUST
+    # grant the permissions CodeQL needs. Language defaults to
+    # javascript-typescript / build-mode none, which is correct for this repo.
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       packages: read
       actions: read
       contents: read
+    steps:
+      - uses: jabrown93/ci/actions/codeql@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # codeql-v1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   release:
-    uses: jabrown93/.github/.github/workflows/npm-release.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
+    uses: jabrown93/ci/.github/workflows/npm-release.yml@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # workflows-v1.0.0
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,8 +5,12 @@ on:
     - cron: '30 1 * * *'
 jobs:
   stale:
-    uses: jabrown93/.github/.github/workflows/stale.yml@71c3af9fc09ce87b086cc058773380acaf2b1299 # v1.2.0
+    # stale is now a composite action, so the caller owns runs-on and MUST grant
+    # the permissions actions/stale needs. The schedule trigger stays here.
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       issues: write
       pull-requests: write
+    steps:
+      - uses: jabrown93/ci/actions/stale@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # stale-v1.0.0

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -25,70 +25,82 @@ import process from 'node:process';
 const isReleaseDeps = process.env.RELEASE_DEPS === 'true';
 
 const depReleaseRules = [
-	// Required: commit-analyzer evaluates every matching custom rule and keeps
-	// the highest release type, so without this a breaking fix(deps)! would
-	// match ONLY the suppression rule below and never release. Listed first so
-	// the analyzer short-circuits on major.
-	{
-		type: 'fix', scope: 'deps', breaking: true, release: 'major',
-	},
-	isReleaseDeps
-		? {type: 'fix', scope: 'deps', release: 'patch'}
-		: {type: 'fix', scope: 'deps', release: false},
+  // Required: commit-analyzer evaluates every matching custom rule and keeps
+  // the highest release type, so without this a breaking fix(deps)! would
+  // match ONLY the suppression rule below and never release. Listed first so
+  // the analyzer short-circuits on major.
+  {
+    type: 'fix',
+    scope: 'deps',
+    breaking: true,
+    release: 'major',
+  },
+  isReleaseDeps
+    ? { type: 'fix', scope: 'deps', release: 'patch' }
+    : { type: 'fix', scope: 'deps', release: false },
 ];
 
 const noteKeywords = ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING'];
 
 const releaseConfig = {
-	branches: ['main', 'next', {name: 'beta', prerelease: true}, {name: 'alpha', prerelease: true}],
-	preset: 'conventionalcommits',
-	plugins: [
-		[
-			'@semantic-release/commit-analyzer',
-			{parserOpts: {noteKeywords}, releaseRules: depReleaseRules},
-		],
-		[
-			'@semantic-release/exec',
-			{
-				prepareCmd:
+  branches: [
+    'main',
+    'next',
+    { name: 'beta', prerelease: true },
+    { name: 'alpha', prerelease: true },
+  ],
+  preset: 'conventionalcommits',
+  plugins: [
+    [
+      '@semantic-release/commit-analyzer',
+      { parserOpts: { noteKeywords }, releaseRules: depReleaseRules },
+    ],
+    [
+      '@semantic-release/exec',
+      {
+        prepareCmd:
           // eslint-disable-next-line no-template-curly-in-string -- ${branch.type} is expanded by semantic-release, not JS
-          'test ${branch.type} != release || sed -i \'/^## \\[/h;x;/^[^]]*-/{x;d};x\' CHANGELOG.md',
-			},
-		],
-		[
-			'@semantic-release/release-notes-generator',
-			{
-				parserOpts: {noteKeywords},
-				writerOpts: {commitsSort: ['subject', 'scope']},
-			},
-		],
-		[
-			'@semantic-release/changelog',
-			{
-				changelogTitle:
+          "test ${branch.type} != release || sed -i '/^## \\[/h;x;/^[^]]*-/{x;d};x' CHANGELOG.md",
+      },
+    ],
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        parserOpts: { noteKeywords },
+        writerOpts: { commitsSort: ['subject', 'scope'] },
+      },
+    ],
+    [
+      '@semantic-release/changelog',
+      {
+        changelogTitle:
           '# Changelog\n\nAll notable changes to this project will be documented in this file. See\n[Conventional Commits](https://conventionalcommits.org) for commit guidelines.',
-			},
-		],
-		['@semantic-release/npm', {tarballDir: 'dist'}],
-		[
-			'@semantic-release/exec',
-			{
-				prepareCmd:
+      },
+    ],
+    ['@semantic-release/npm', { tarballDir: 'dist' }],
+    [
+      '@semantic-release/exec',
+      {
+        prepareCmd:
           'npx --yes @cyclonedx/cyclonedx-npm@4.2.1 --ignore-npm-errors --output-format JSON --output-file sbom.cdx.json',
-			},
-		],
-		[
-			'@semantic-release/github',
-			{
-				assets: [{path: 'sbom.cdx.json', label: 'CycloneDX SBOM (sbom.cdx.json)'}],
-			},
-		],
-		[
-			'@semantic-release/git',
-			// eslint-disable-next-line no-template-curly-in-string -- ${nextRelease.*} is expanded by semantic-release, not JS
-			{message: 'ci(release): ${nextRelease.version}\n\n${nextRelease.notes}'},
-		],
-	],
+      },
+    ],
+    [
+      '@semantic-release/github',
+      {
+        assets: [
+          { path: 'sbom.cdx.json', label: 'CycloneDX SBOM (sbom.cdx.json)' },
+        ],
+      },
+    ],
+    [
+      '@semantic-release/git',
+      // eslint-disable-next-line no-template-curly-in-string -- ${nextRelease.*} is expanded by semantic-release, not JS
+      {
+        message: 'ci(release): ${nextRelease.version}\n\n${nextRelease.notes}',
+      },
+    ],
+  ],
 };
 
 export default releaseConfig;

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,11 +1,11 @@
 const commitlintConfig = {
-	extends: ['@commitlint/config-conventional'],
-	rules: {
-		'body-max-line-length': [2, 'never', '500'],
-		'body-max-length': [2, 'never', '2000'],
-		'footer-max-line-length': [2, 'never', '500'],
-		'subject-case': [2, 'never', ['upper-case', 'pascal-case', 'start-case']],
-	},
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [2, 'never', '500'],
+    'body-max-length': [2, 'never', '2000'],
+    'footer-max-line-length': [2, 'never', '500'],
+    'subject-case': [2, 'never', ['upper-case', 'pascal-case', 'start-case']],
+  },
 };
 
 export default commitlintConfig;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import tsParser from '@typescript-eslint/parser';
 import js from '@eslint/js';
 import { FlatCompat } from '@eslint/eslintrc';
+import eslintConfigPrettier from 'eslint-config-prettier';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -78,6 +79,7 @@ const eslintConfig = [
       '@typescript-eslint/explicit-module-boundary-types': 'off',
     },
   },
+  eslintConfigPrettier,
 ];
 
 export default eslintConfig;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,83 +1,83 @@
 import path from 'node:path';
-import {fileURLToPath} from 'node:url';
+import { fileURLToPath } from 'node:url';
 import tsParser from '@typescript-eslint/parser';
 import js from '@eslint/js';
-import {FlatCompat} from '@eslint/eslintrc';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-	baseDirectory: __dirname,
-	recommendedConfig: js.configs.recommended,
-	allConfig: js.configs.all,
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
 });
 
 const eslintConfig = [
-	{
-		ignores: [
-			'**/homebridge-ui',
-			'**/dist',
-			'package-lock.json',
-			'package.json',
-		],
-	},
-	...compat.extends(
-		'eslint:recommended',
-		'plugin:@typescript-eslint/eslint-recommended',
-		'plugin:@typescript-eslint/recommended',
-	),
-	{
-		languageOptions: {
-			parser: tsParser,
-			ecmaVersion: 2018,
-			sourceType: 'module',
-		},
+  {
+    ignores: [
+      '**/homebridge-ui',
+      '**/dist',
+      'package-lock.json',
+      'package.json',
+    ],
+  },
+  ...compat.extends(
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended'
+  ),
+  {
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2018,
+      sourceType: 'module',
+    },
 
-		rules: {
-			quotes: ['warn', 'single'],
+    rules: {
+      quotes: ['warn', 'single'],
 
-			indent: [
-				'warn',
-				'tab',
-				{
-					SwitchCase: 1,
-				},
-			],
+      indent: [
+        'warn',
+        'tab',
+        {
+          SwitchCase: 1,
+        },
+      ],
 
-			semi: ['off'],
-			'comma-dangle': ['warn', 'only-multiline'],
-			'dot-notation': 'off',
-			eqeqeq: 'warn',
-			curly: ['warn', 'multi-or-nest', 'consistent'],
-			'brace-style': ['warn'],
-			'prefer-arrow-callback': ['warn'],
-			'max-len': ['warn', 140],
-			'no-console': ['warn'],
-			'no-non-null-assertion': ['off'],
-			'comma-spacing': ['error'],
+      semi: ['off'],
+      'comma-dangle': ['warn', 'only-multiline'],
+      'dot-notation': 'off',
+      eqeqeq: 'warn',
+      curly: ['warn', 'multi-or-nest', 'consistent'],
+      'brace-style': ['warn'],
+      'prefer-arrow-callback': ['warn'],
+      'max-len': ['warn', 140],
+      'no-console': ['warn'],
+      'no-non-null-assertion': ['off'],
+      'comma-spacing': ['error'],
 
-			'no-multi-spaces': [
-				'warn',
-				{
-					ignoreEOLComments: true,
-				},
-			],
+      'no-multi-spaces': [
+        'warn',
+        {
+          ignoreEOLComments: true,
+        },
+      ],
 
-			'no-trailing-spaces': ['warn'],
+      'no-trailing-spaces': ['warn'],
 
-			'lines-between-class-members': [
-				'warn',
-				'always',
-				{
-					exceptAfterSingleLine: true,
-				},
-			],
+      'lines-between-class-members': [
+        'warn',
+        'always',
+        {
+          exceptAfterSingleLine: true,
+        },
+      ],
 
-			'@typescript-eslint/explicit-function-return-type': 'off',
-			'@typescript-eslint/no-non-null-assertion': 'off',
-			'@typescript-eslint/explicit-module-boundary-types': 'off',
-		},
-	},
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "conventional-changelog-conventionalcommits": "9.3.1",
         "cross-env": "10.1.0",
         "eslint": "10.7.0",
-        "eslint-plugin-ava": "17.0.1",
+        "eslint-config-prettier": "10.1.8",
         "eslint-plugin-json": "4.0.1",
         "eslint-plugin-unicorn": "71.1.0",
         "homebridge": "2.1.1",
@@ -48,7 +48,7 @@
         "ts-node": "10.9.2",
         "typescript": "6.0.3",
         "typescript-eslint": "8.64.0",
-        "xo": "4.0.0"
+        "vitest": "4.1.10"
       },
       "engines": {
         "homebridge": "^1.8.0 || ^2.0.0-beta.0",
@@ -467,21 +467,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -490,9 +490,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -506,63 +506,6 @@
       "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.88.0.tgz",
-      "integrity": "sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.9",
-        "@typescript-eslint/types": "^8.59.4",
-        "comment-parser": "1.4.7",
-        "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@es-joy/resolve.exports": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
-      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-4.7.2.tgz",
-      "integrity": "sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "ignore": "^7.0.5"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/@eslint-community/eslint-plugin-eslint-comments/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -591,27 +534,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
-      "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": "^8.40 || 9 || 10"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/config-array": {
@@ -689,35 +611,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/css": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/css/-/css-1.4.0.tgz",
-      "integrity": "sha512-OnRNKgnbX+tufPuZc2kOJS+v1iIARvfJHRNEAVwN77DBpojl+rGjEP8NKTL6pEZ7BR+HtwIuSSdrymEFlANGxg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1",
-        "@eslint/css-tree": "^4.0.4",
-        "@eslint/plugin-kit": "^0.7.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/css-tree": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-4.0.4.tgz",
-      "integrity": "sha512-nxMparyhqVWQvadx9x8dIfubfIPOE+X2b2waua8fzdnM9vdp9rgVtwEZlG0TmCwEUz/d/f40fzvO/eqBwdxz0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.28.1",
-        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -813,48 +706,6 @@
         "eslint": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@eslint/json": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.1.tgz",
-      "integrity": "sha512-Thz2j92ceUF3Bq/0TuWb3MWn3Z+Cwc8k5ptF0fakl2D4Mp8mSx07Xr1aQM4R5NoihzarWUdxfOmQ8DesGy4jOg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
-        "@humanwhocodes/momoa": "^3.3.10",
-        "natural-compare": "^1.4.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/markdown": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.3.tgz",
-      "integrity": "sha512-rBTSSShrq7e4O+PWfeE4azH4/CWPNrC+VGxBXiW00o3vYVJnznsZiDayj3KC9JztIMVRZxZHn2nrDIUau/4j7A==",
-      "dev": true,
-      "license": "MIT",
-      "workspaces": [
-        "examples/*"
-      ],
-      "dependencies": {
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
-        "github-slugger": "^2.0.0",
-        "mdast-util-from-markdown": "^2.0.2",
-        "mdast-util-frontmatter": "^2.0.1",
-        "mdast-util-gfm": "^3.1.0",
-        "mdast-util-math": "^3.0.0",
-        "micromark-extension-frontmatter": "^2.0.0",
-        "micromark-extension-gfm": "^3.0.0",
-        "micromark-extension-math": "^3.1.0",
-        "micromark-util-normalize-identifier": "^2.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1314,116 +1165,6 @@
         "node": ">=18.0.0 <25.0.0"
       }
     },
-    "node_modules/@html-eslint/core": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/core/-/core-0.63.0.tgz",
-      "integrity": "sha512-fy9Mp8LCcOY4MrJiRoRWULURWYA4KWCKxG5Aa0VNbfR4Zs+CNbSCYjpgOmPr1RIvyHqvbVdeHpHL+iTKLiZnPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@html-eslint/types": "^0.63.0",
-        "html-standard": "^0.0.13"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@html-eslint/eslint-plugin": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/eslint-plugin/-/eslint-plugin-0.63.0.tgz",
-      "integrity": "sha512-C0MLdS1BPeB23G7w4Y+4ojnOXTew8rwNXRK5TlShsNdo4b8GSYe9lt+tCyxPr2B0iz+kqvYEXnKP0HAUsvfUJQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/plugin-kit": "^0.4.1",
-        "@html-eslint/core": "^0.63.0",
-        "@html-eslint/parser": "^0.63.0",
-        "@html-eslint/template-parser": "^0.63.0",
-        "@html-eslint/template-syntax-parser": "^0.63.0",
-        "@html-eslint/types": "^0.63.0",
-        "@rviscomi/capo.js": "^2.1.0",
-        "html-standard": "^0.0.13"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.0.0 || ^10.0.0-0"
-      }
-    },
-    "node_modules/@html-eslint/eslint-plugin/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@html-eslint/eslint-plugin/node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@html-eslint/parser": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/parser/-/parser-0.63.0.tgz",
-      "integrity": "sha512-zEPbNVJf0C50l4X1C7FV5ig+c+8veD54HGicMdVc9PgB+cjMGcxgInv8yPbBWSSgSSFZZcFwo/Z4XqcPLPK99Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@html-eslint/template-syntax-parser": "^0.63.0",
-        "@html-eslint/types": "^0.63.0",
-        "css-tree": "^3.1.0",
-        "es-html-parser": "0.3.1"
-      }
-    },
-    "node_modules/@html-eslint/template-parser": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.63.0.tgz",
-      "integrity": "sha512-eut/idEvs99oJ4PG1Ipxc/uD/r8PZF6bjJGK02EqFpDRqAnbegEFSR5VKoWMhprbVAyLrtdVeTJKLBdQC8xMpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@html-eslint/types": "^0.63.0",
-        "es-html-parser": "0.3.1"
-      }
-    },
-    "node_modules/@html-eslint/template-syntax-parser": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.63.0.tgz",
-      "integrity": "sha512-MOdc7WmFcMiVbhwPDquXPfR1xTuqhyjy+jh9GEyV4lXYVwX6ATqReLIowZ7z8qNxZ8f9jwQuhktVhHhC6rtiQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@html-eslint/types": "^0.63.0"
-      }
-    },
-    "node_modules/@html-eslint/types": {
-      "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@html-eslint/types/-/types-0.63.0.tgz",
-      "integrity": "sha512-1YclN0Cg2QbUsit0I+SOM2o/66PRcAgw5pkxDjySCOUCbi85DrVZAAbV15ro+YVomYMPqosn3E2IdVCkchgrtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/css-tree": "^2.3.11",
-        "@types/estree": "^1.0.6",
-        "es-html-parser": "0.3.1"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1474,16 +1215,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@humanwhocodes/momoa": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.10.tgz",
-      "integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@humanwhocodes/retry": {
@@ -1973,44 +1704,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@nuxt/opencollective": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
@@ -2247,25 +1940,22 @@
         "@otplib/core": "13.4.1"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@pkgr/core": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
-      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pkgr"
-      }
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -2305,12 +1995,287 @@
         "node": ">=12"
       }
     },
-    "node_modules/@rviscomi/capo.js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@rviscomi/capo.js/-/capo.js-2.1.0.tgz",
-      "integrity": "sha512-y6J+KJqsrY8AcDswLKkvd8KdpFindjS4Q9rSuK8CIpsQOepEjgRaMR4S8OtuLOQoVYLCROT3ffMQqRWrUMQdQA==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
@@ -2907,19 +2872,6 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/@sindresorhus/base62": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
-      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -2947,19 +2899,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@sindresorhus/tsconfig": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-8.1.0.tgz",
-      "integrity": "sha512-MggpguA4jNdtyoUy2Hs54nb4lP4rbhH34CsOiFId1q6fmFPnipqeo70ZRkjp5p4Z7wdyspALtSAcKaxL2/3waQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -2967,39 +2906,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
-      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/types": "^8.56.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "estraverse": "^5.3.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": "^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
+      "license": "MIT"
     },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
@@ -3079,6 +2991,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -3089,33 +3012,12 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/css-tree": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/@types/css-tree/-/css-tree-2.3.11.tgz",
-      "integrity": "sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==",
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/debug": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
-      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -3130,16 +3032,6 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/hast": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
-      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
@@ -3166,23 +3058,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/katex": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
-      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -3204,13 +3079,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3513,355 +3381,118 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
-      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
-      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
-      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
-      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
-      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
-      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
-      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
-      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
-      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
-      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
-      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
-      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
-      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
-      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
-      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
-      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
-      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
-      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
-      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
-      "engines": {
-        "node": ">=14.0.0"
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
-      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
     },
-    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
-      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
-      "cpu": [
-        "ia32"
-      ],
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
-    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
-      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
-    "node_modules/@vscode/l10n": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
-      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -4056,16 +3687,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/are-docs-informative": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
-      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -4108,17 +3729,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/arrify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
-      "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/async": {
@@ -4457,22 +4075,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4518,15 +4120,14 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/ccount": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4558,17 +4159,6 @@
       "peer": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/character-entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -5090,23 +4680,6 @@
         "node": ">=22.12.0"
       }
     },
-    "node_modules/comment-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
-      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/common-path-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -5142,13 +4715,6 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/confusing-browser-globals": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
-      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -5286,6 +4852,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -5516,27 +5089,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/css-tree/node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -5573,20 +5125,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decode-named-character-reference": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
-      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/decompress-response": {
@@ -5627,49 +5165,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -5722,20 +5217,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/devlop": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/diff": {
@@ -5904,20 +5385,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/enhanced-resolve": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/env-ci": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
@@ -6063,19 +5530,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/env-editor": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-1.3.0.tgz",
-      "integrity": "sha512-EqiD/j01PooUbeWk+etUo2TWoocjoxMfGNYpS9e47glIJ5r8WepycIki+LCbonFbPdwlqY5ETeSTAJVMih4z4w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -6129,10 +5583,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-html-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.3.1.tgz",
-      "integrity": "sha512-YTEasG4xt7FEN4b6qJIPbFo/fzQ5kjRMEQ33QMqSXTvfXqAbC2rHxo32x2/1Rhq7Mlu6wI3MIpM5Kf2VHPXrUQ==",
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6265,22 +5719,6 @@
         }
       }
     },
-    "node_modules/eslint-compat-utils": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
-      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "eslint": ">=6.0.0"
-      }
-    },
     "node_modules/eslint-config-prettier": {
       "version": "10.1.8",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
@@ -6297,434 +5735,6 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-config-xo": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.57.0.tgz",
-      "integrity": "sha512-uVE7RWO+kd77OMLoB4BofzlsmB978oVpeEgQgmzfQUpb+nJ1OmI3I2z5cQgt/bi0WAwSnoMMY46moGajG39KPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
-        "@eslint/compat": "^2.1.0",
-        "@eslint/css": "^1.4.0",
-        "@eslint/json": "^2.0.1",
-        "@eslint/markdown": "^8.0.3",
-        "@html-eslint/eslint-plugin": "^0.63.0",
-        "@stylistic/eslint-plugin": "^5.10.0",
-        "confusing-browser-globals": "1.0.11",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-import-resolver-typescript": "^4.4.5",
-        "eslint-node-test": "^0.2.0",
-        "eslint-plugin-ava": "^17.0.1",
-        "eslint-plugin-import-x": "^4.17.1",
-        "eslint-plugin-jsdoc": "^63.0.12",
-        "eslint-plugin-n": "^18.2.1",
-        "eslint-plugin-prettier": "^5.5.6",
-        "eslint-plugin-regexp": "^3.1.1",
-        "eslint-plugin-unicorn": "^71.0.0",
-        "globals": "^17.7.0",
-        "typescript-eslint": "^8.62.1"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      },
-      "peerDependencies": {
-        "eslint": ">=10",
-        "prettier": ">=3",
-        "typescript": ">=6"
-      },
-      "peerDependenciesMeta": {
-        "prettier": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-config-xo/node_modules/eslint-import-resolver-typescript": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
-      "integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "debug": "^4.4.1",
-        "eslint-import-context": "^0.1.8",
-        "get-tsconfig": "^4.10.1",
-        "is-bun-module": "^2.0.0",
-        "stable-hash-x": "^0.2.0",
-        "tinyglobby": "^0.2.14",
-        "unrs-resolver": "^1.7.11"
-      },
-      "engines": {
-        "node": "^16.17.0 || >=18.6.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-import-resolver-typescript"
-      },
-      "peerDependencies": {
-        "eslint": "*",
-        "eslint-plugin-import": "*",
-        "eslint-plugin-import-x": "*"
-      },
-      "peerDependenciesMeta": {
-        "eslint-plugin-import": {
-          "optional": true
-        },
-        "eslint-plugin-import-x": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-config-xo/node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-formatter-pretty": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-7.1.0.tgz",
-      "integrity": "sha512-iyPrgpwKC3MMM75Wxn0VouD89HolpG+BL95NOxgwOWO0R+Omapo7gFX2xcGVsUDS7KiXLtDuynLbNbOARSE7YA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "^9.6.1",
-        "ansi-escapes": "^7.1.0",
-        "chalk": "^5.6.2",
-        "eslint-rule-docs": "^1.1.235",
-        "log-symbols": "^7.0.1",
-        "plur": "^5.1.0",
-        "string-width": "^8.1.0",
-        "supports-hyperlinks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-formatter-pretty/node_modules/has-flag": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
-      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-formatter-pretty/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/eslint-formatter-pretty/node_modules/supports-hyperlinks": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.5.0.tgz",
-      "integrity": "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^5.0.1",
-        "supports-color": "^10.2.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
-      }
-    },
-    "node_modules/eslint-import-context": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
-      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-tsconfig": "^4.10.1",
-        "stable-hash-x": "^0.2.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-import-context"
-      },
-      "peerDependencies": {
-        "unrs-resolver": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "unrs-resolver": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-node-test": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-node-test/-/eslint-node-test-0.2.0.tgz",
-      "integrity": "sha512-JnP6034mkFxGL9mWVrhADT3EOTpDmHwYILS40OeSGthpTkG3SUIyd6EcRhPAupWUjw6MbgfpR74/n3K4ssG8Uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "quote-js-string": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/eslint-node-test?sponsor=1"
-      },
-      "peerDependencies": {
-        "eslint": ">=10.4"
-      }
-    },
-    "node_modules/eslint-plugin-ava": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-17.0.1.tgz",
-      "integrity": "sha512-l2K1XWF0BgBcc+kJfObY4ijzRCniStxAMCtDEEu8RzTmICNv07+JqJHGNkThluu1PxDvQdNZedvyc2+SUus1qg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@eslint/json": "^2.0.0",
-        "espree": "^11.2.0",
-        "espurify": "^3.2.0",
-        "micro-spelling-correcter": "^1.1.1",
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "eslint": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-ava/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-ava/node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-es-x": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
-      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/ota-meshi",
-        "https://opencollective.com/eslint"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.1.2",
-        "@eslint-community/regexpp": "^4.11.0",
-        "eslint-compat-utils": "^0.5.1"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8"
-      }
-    },
-    "node_modules/eslint-plugin-import-x": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.1.tgz",
-      "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "^8.56.0",
-        "comment-parser": "^1.4.1",
-        "debug": "^4.4.1",
-        "eslint-import-context": "^0.1.9",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.3 || ^10.1.2",
-        "semver": "^7.7.2",
-        "stable-hash-x": "^0.2.0",
-        "unrs-resolver": "^1.9.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-import-x"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/utils": "^8.56.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "eslint-import-resolver-node": "*"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/utils": {
-          "optional": true
-        },
-        "eslint-import-resolver-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-import-x/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.0.13",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.13.tgz",
-      "integrity": "sha512-ahG1kWA8jYNwaQJtzJlnF+v4Gb9w5r+WL98gp+L8qjLN9ErpL5sevGuemN+fCYsU3Np27F36KmDc8UPi1ml/dg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.88.0",
-        "@es-joy/resolve.exports": "1.2.0",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.7",
-        "debug": "^4.4.3",
-        "escape-string-regexp": "^4.0.0",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
-        "html-entities": "^2.6.0",
-        "object-deep-merge": "^2.0.1",
-        "parse-imports-exports": "^0.2.4",
-        "semver": "^7.8.5",
-        "spdx-expression-parse": "^4.0.0",
-        "to-valid-identifier": "^1.0.0"
-      },
-      "engines": {
-        "node": "^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/spdx-expression-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
-      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
     "node_modules/eslint-plugin-json": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-4.0.1.tgz",
@@ -6737,108 +5747,6 @@
       },
       "engines": {
         "node": ">=18.0"
-      }
-    },
-    "node_modules/eslint-plugin-n": {
-      "version": "18.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.2.2.tgz",
-      "integrity": "sha512-gOO0lIqwEjZ750kv9/SptCWArUoAZXJoBr0vYWTO2dCBxctHUXlBIigiC8xuxxr/NKqgIT6Ehz1xRcilj8a5cA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.5.0",
-        "enhanced-resolve": "^5.17.1",
-        "eslint-plugin-es-x": "^7.8.0",
-        "get-tsconfig": "^4.8.1",
-        "globals": "^15.11.0",
-        "globrex": "^0.1.2",
-        "ignore": "^5.3.2",
-        "semver": "^7.6.3"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.57.1",
-        "ts-declaration-location": "^1.0.6",
-        "typescript": ">=5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ts-declaration-location": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-n/node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
-      "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.13"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-regexp": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-3.1.1.tgz",
-      "integrity": "sha512-MxR5nqoQCtVWmJwia0D2+NlXX1xzdpkslsVOZLEYQ4PQWEaL65PCZXURxaBc3lPnkNFpNxzMIRmYVxdl8giXRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.11.0",
-        "comment-parser": "^1.4.0",
-        "jsdoc-type-pratt-parser": "^7.0.0",
-        "refa": "^0.12.1",
-        "regexp-ast-analysis": "^0.7.1",
-        "scslre": "^0.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": ">=9.38.0"
       }
     },
     "node_modules/eslint-plugin-unicorn": {
@@ -6901,13 +5809,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/eslint-rule-docs": {
-      "version": "1.1.235",
-      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
-      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
@@ -7066,13 +5967,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/espurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-3.2.0.tgz",
-      "integrity": "sha512-+jfGpC1eUu7s4M8sXnnoUsQfEQ1qqkEr/S+V47QR+GC/NODe98s4iPYq/2KrNaS1guTjHBhMS4j9N3NOObT1WQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -7107,6 +6001,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/esutils": {
@@ -7179,6 +6083,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
@@ -7198,43 +6112,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -7380,20 +6257,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fault": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
-      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "format": "^0.2.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -7471,23 +6334,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/find-cache-directory": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/find-cache-directory/-/find-cache-directory-6.0.0.tgz",
-      "integrity": "sha512-CvFd5ivA6HcSHbD+59P7CyzINHXzwhuQK8RY7CxJZtgDSAtRlHiCaQpZQ2lMR/WRyUIEmzUvL6G2AGurMfegZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "common-path-prefix": "^3.0.0",
-        "pkg-dir": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-my-way": {
@@ -7610,15 +6456,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/format": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/from": {
@@ -7760,19 +6597,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stdin": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-10.0.0.tgz",
-      "integrity": "sha512-eWSePJ4zXFdqz+/Lyfopob4rIcoF/U2XfE8nJc7iZV6lnebWc9k7DoQQpX+2a9jc0AOvBsXvbe5YkjXl/MHbpg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-stream": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
@@ -7788,19 +6612,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/git-log-parser": {
@@ -7836,13 +6647,6 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -7942,57 +6746,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/globby": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.1.tgz",
-      "integrity": "sha512-JmsqJalahxxgW8V2ecSQ2G7UjPlI9cpKdrkG9KoNiXhd/YslXOTEB0cViENWUznuovIuNT+FkMbraDGjr4FCUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.5",
-        "is-path-inside": "^4.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/globby/node_modules/unicorn-magic": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
-      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -8273,34 +7026,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/html-entities": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/html-standard": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/html-standard/-/html-standard-0.0.13.tgz",
-      "integrity": "sha512-6oNfW3c1t44O7jVXu0tp4E5MbHifWlXrHlZBPt6y7vFdgLOUUh8hyzoRhfUgozlBUK6oLLYhqP1uIqbZ8ggcBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vscode-css-languageservice": "^6.3.9",
-        "vscode-languageserver-textdocument": "^1.0.12"
-      }
-    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -8564,16 +7289,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/irregular-plurals": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
-      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -8605,32 +7320,6 @@
       },
       "engines": {
         "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-bun-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
-      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.7.1"
-      }
-    },
-    "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8692,38 +7381,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-in-ssh": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
-      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -8755,19 +7412,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -8815,22 +7459,6 @@
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is2": {
       "version": "2.0.9",
@@ -8936,16 +7564,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.mjs"
-      }
-    },
-    "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
-      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -9093,33 +7711,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "dev": true,
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
-    "node_modules/katex/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -9190,33 +7781,277 @@
       ],
       "license": "MIT"
     },
-    "node_modules/line-column-path": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/line-column-path/-/line-column-path-4.0.0.tgz",
-      "integrity": "sha512-Zvpvd56i9FRV5kaJFiiY1t+FNMEH+dGEaLyQprqKlGHBAxJXmdSk+8tVsh6b9YlxbfyyuLrhJCkzwB+AmOBZ0g==",
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
-      "license": "MIT",
+      "license": "MPL-2.0",
       "dependencies": {
-        "unicorn-magic": "^0.4.0"
+        "detect-libc": "^2.0.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">= 12.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/line-column-path/node_modules/unicorn-magic": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
-      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "MIT",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=20"
+        "node": ">= 12.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lines-and-columns": {
@@ -9531,17 +8366,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/longest-streak": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
-      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -9576,6 +8400,16 @@
         "darwin"
       ]
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-asynchronous": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
@@ -9607,17 +8441,6 @@
       "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/markdown-table": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
-      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/marked": {
       "version": "15.0.12",
@@ -9666,278 +8489,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mdast-util-find-and-replace": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
-      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
-      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark": "^4.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-frontmatter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
-      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "escape-string-regexp": "^5.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "micromark-extension-frontmatter": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mdast-util-gfm": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
-      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-gfm-autolink-literal": "^2.0.0",
-        "mdast-util-gfm-footnote": "^2.0.0",
-        "mdast-util-gfm-strikethrough": "^2.0.0",
-        "mdast-util-gfm-table": "^2.0.0",
-        "mdast-util-gfm-task-list-item": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-find-and-replace": "^3.0.0",
-        "micromark-util-character": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.1.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-strikethrough": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
-      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
-      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "markdown-table": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-gfm-task-list-item": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
-      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-math": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
-      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "devlop": "^1.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.1.0",
-        "unist-util-remove-position": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-phrasing": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
-      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-markdown": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
-      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "longest-streak": "^3.0.0",
-        "mdast-util-phrasing": "^4.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-decode-string": "^2.0.0",
-        "unist-util-visit": "^5.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
-      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.28.1.tgz",
-      "integrity": "sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -9965,651 +8516,6 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micro-spelling-correcter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
-      "integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/micromark": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
-      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-core-commonmark": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
-      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-factory-destination": "^2.0.0",
-        "micromark-factory-label": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-factory-title": "^2.0.0",
-        "micromark-factory-whitespace": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-html-tag-name": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-subtokenize": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-frontmatter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
-      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fault": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
-      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "micromark-extension-gfm-autolink-literal": "^2.0.0",
-        "micromark-extension-gfm-footnote": "^2.0.0",
-        "micromark-extension-gfm-strikethrough": "^2.0.0",
-        "micromark-extension-gfm-table": "^2.0.0",
-        "micromark-extension-gfm-tagfilter": "^2.0.0",
-        "micromark-extension-gfm-task-list-item": "^2.0.0",
-        "micromark-util-combine-extensions": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-autolink-literal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
-      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-footnote": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
-      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-core-commonmark": "^2.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-normalize-identifier": "^2.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-strikethrough": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
-      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-classify-character": "^2.0.0",
-        "micromark-util-resolve-all": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-table": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
-      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-tagfilter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
-      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-gfm-task-list-item": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
-      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-extension-math": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
-      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/katex": "^0.16.0",
-        "devlop": "^1.0.0",
-        "katex": "^0.16.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/micromark-factory-destination": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
-      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-label": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
-      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-space": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
-      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-title": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
-      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-whitespace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
-      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-chunked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
-      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-classify-character": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
-      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-combine-extensions": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
-      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-numeric-character-reference": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
-      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-string": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
-      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-decode-numeric-character-reference": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-encode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-html-tag-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
-      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-normalize-identifier": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
-      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-resolve-all": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
-      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-subtokenize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
-      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-util-chunked": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-symbol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/micromark-util-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -10820,28 +8726,31 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/napi-postinstall": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
-      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "napi-postinstall": "lib/cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/napi-postinstall"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -13093,13 +11002,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-deep-merge": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
-      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
@@ -13108,6 +11010,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -13141,46 +11057,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.4.0",
-        "define-lazy-prop": "^3.0.0",
-        "is-in-ssh": "^1.0.0",
-        "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.1.0",
-        "wsl-utils": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open-editor": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/open-editor/-/open-editor-6.0.0.tgz",
-      "integrity": "sha512-LGd2Xn6NvFlbx/lg/HK69w6Dbg+21MzJzcPDPQRgDRqc+qiR+2/SN99rzZSo7Qa1ck1hcGYig0CAo53cmXCE0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-editor": "^1.3.0",
-        "execa": "^9.6.0",
-        "line-column-path": "^4.0.0",
-        "open": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13431,16 +11307,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-imports-exports": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
-      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse-statements": "1.0.11"
-      }
-    },
     "node_modules/parse-json": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
@@ -13471,13 +11337,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/parse-statements": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
-      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "5.1.1",
@@ -13602,6 +11461,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pause": {
       "version": "0.0.1",
@@ -13795,38 +11661,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/pkg-dir": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-8.0.0.tgz",
-      "integrity": "sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up-simple": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/plur": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-5.1.0.tgz",
-      "integrity": "sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "irregular-plurals": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -13858,17 +11692,33 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/powershell-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "license": "MIT",
-      "engines": {
-        "node": ">=20"
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prebuild-install": {
@@ -13923,19 +11773,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
-      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-ms": {
@@ -14061,27 +11898,6 @@
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
@@ -14337,39 +12153,12 @@
         "node": ">= 12.13.0"
       }
     },
-    "node_modules/refa": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
-      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.8.0"
-      },
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/regexp-ast-analysis": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
-      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.8.0",
-        "refa": "^0.12.1"
-      },
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
     },
     "node_modules/registry-auth-token": {
       "version": "5.1.1",
@@ -14441,16 +12230,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -14516,41 +12295,38 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
-        "queue-microtask": "^1.2.2"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/rxjs": {
@@ -14611,21 +12387,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
-      }
-    },
-    "node_modules/scslre": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
-      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.8.0",
-        "refa": "^0.12.0",
-        "regexp-ast-analysis": "^0.7.0"
-      },
-      "engines": {
-        "node": "^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/secure-json-parse": {
@@ -14904,6 +12665,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -15079,19 +12847,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/slice-ansi": {
@@ -15270,15 +13025,12 @@
         "node": ">= 10.x"
       }
     },
-    "node_modules/stable-hash-x": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
-      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -15289,6 +13041,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.2",
@@ -15530,22 +13289,6 @@
         "@scarf/scarf": "=1.4.0"
       }
     },
-    "node_modules/synckit": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
-      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pkgr/core": "^0.3.6"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/synckit"
-      }
-    },
     "node_modules/systeminformation": {
       "version": "5.31.7",
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.7.tgz",
@@ -15594,20 +13337,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar": {
@@ -15857,6 +13586,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -15884,6 +13620,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -15895,23 +13641,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/to-valid-identifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
-      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/base62": "^1.0.0",
-        "reserved-identifiers": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/toad-cache": {
@@ -16239,80 +13968,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
-      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-remove-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
-      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
-      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
-      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
@@ -16328,44 +13983,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/unrs-resolver": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
-      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "napi-postinstall": "^0.3.4"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unrs-resolver"
-      },
-      "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
-        "@unrs/resolver-binding-android-arm64": "1.12.2",
-        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
-        "@unrs/resolver-binding-darwin-x64": "1.12.2",
-        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
-        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
-        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
-        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/unzipper": {
@@ -16488,17 +14105,172 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/vscode-css-languageservice": {
-      "version": "6.3.10",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
-      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vscode/l10n": "^0.0.18",
-        "vscode-languageserver-textdocument": "^1.0.12",
-        "vscode-languageserver-types": "3.17.5",
-        "vscode-uri": "^3.1.0"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "node_modules/vscode-json-languageservice": {
@@ -16566,6 +14338,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -16630,23 +14419,6 @@
         }
       }
     },
-    "node_modules/wsl-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0",
-        "powershell-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -16669,92 +14441,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/xo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xo/-/xo-4.0.0.tgz",
-      "integrity": "sha512-230aBWg2e2oAB1R60mh/naJ50k0YfLdkb4LZEn4D1WzaQwDxjj6btnoFPX/Go4E7EPhkKpsgZf4KllcL0XlPUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/tsconfig": "^8.1.0",
-        "arrify": "^3.0.0",
-        "cosmiconfig": "^9.0.2",
-        "define-lazy-prop": "^3.0.0",
-        "eslint": "^10.6.0",
-        "eslint-config-xo": "^0.57.0",
-        "eslint-formatter-pretty": "^7.1.0",
-        "find-cache-directory": "^6.0.0",
-        "get-stdin": "^10.0.0",
-        "get-tsconfig": "^4.14.0",
-        "globby": "^16.2.1",
-        "jiti": "^2.7.0",
-        "meow": "^14.1.0",
-        "micromatch": "^4.0.8",
-        "open-editor": "^6.0.0",
-        "path-exists": "^5.0.0",
-        "prettier": "^3.9.4",
-        "type-fest": "^5.8.0",
-        "typescript": "^6.0.3"
-      },
-      "bin": {
-        "xo": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/xo/node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/xo/node_modules/meow": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
-      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/xo/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/xo/node_modules/type-fest": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
-      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xtend": {
@@ -16892,17 +14578,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "watch": "npm run setup-config && npm run build && npm link && nodemon",
     "semantic-release": "cross-env semantic-release --no-ci",
     "release": "npm-run-all build semantic-release",
-    "test": "xo",
+    "test": "vitest run --passWithNoTests",
     "prepare": "husky",
     "tsc": "tsc --noEmit",
     "setup-config": "if [ ! -f ./test/hbConfig/config.json ]; then cp ./test/hbConfig/config-template.json ./test/hbConfig/config.json; fi",
@@ -51,60 +51,6 @@
       "prettier --write"
     ]
   },
-  "xo": [
-    {
-      "ignores": [
-        "src/eiscp/**",
-        "CHANGELOG.md"
-      ]
-    },
-    {
-      "files": "**/*.ts",
-      "space": false,
-      "rules": {
-        "unicorn/prefer-module": "warn",
-        "unicorn/no-new-array": "warn",
-        "unicorn/no-for-each": "warn",
-        "camelcase": "off",
-        "kebabCase": "off",
-        "no-mixed-spaces-and-tabs": "warn",
-        "no-useless-escape": "warn",
-        "indent": "off",
-        "quotes": [
-          "warn",
-          "single"
-        ],
-        "capitalized-comments": "off",
-        "no-var": "warn",
-        "prefer-destructuring": "off",
-        "prefer-arrow-callback": "warn",
-        "object-shorthand": [
-          "off",
-          "always",
-          {
-            "ignoreConstructors": true
-          }
-        ],
-        "@stylistic/quote-props": [
-          "error",
-          "always"
-        ],
-        "no-unused-vars": "warn",
-        "curly": [
-          "error",
-          "multi-or-nest",
-          "consistent"
-        ],
-        "no-use-before-define": [
-          "error",
-          {
-            "classes": false
-          }
-        ],
-        "new-cap": "off"
-      }
-    }
-  ],
   "dependencies": {
     "async": "^3.2.6",
     "polling-to-event": "^2.1.0"
@@ -130,7 +76,7 @@
     "conventional-changelog-conventionalcommits": "9.3.1",
     "cross-env": "10.1.0",
     "eslint": "10.7.0",
-    "eslint-plugin-ava": "17.0.1",
+    "eslint-config-prettier": "10.1.8",
     "eslint-plugin-json": "4.0.1",
     "eslint-plugin-unicorn": "71.1.0",
     "homebridge": "2.1.1",
@@ -145,7 +91,7 @@
     "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "typescript-eslint": "8.64.0",
-    "xo": "4.0.0"
+    "vitest": "4.1.10"
   },
   "engines": {
     "homebridge": "^1.8.0 || ^2.0.0-beta.0",

--- a/src/eiscp/eiscp.ts
+++ b/src/eiscp/eiscp.ts
@@ -636,7 +636,10 @@ export class Eiscp extends EventEmitter {
     }
   }
 
-  public raw(data, callback?: (error: unknown, message?: string | null) => void) {
+  public raw(
+    data,
+    callback?: (error: unknown, message?: string | null) => void
+  ) {
     /*
         Send a low level command like PWR01
         callback only tells you that the command was sent but not that it succsessfully did what you asked
@@ -652,7 +655,10 @@ export class Eiscp extends EventEmitter {
     }
   }
 
-  public command(data, callback?: (error: unknown, message?: string | null) => void) {
+  public command(
+    data,
+    callback?: (error: unknown, message?: string | null) => void
+  ) {
     /*
         Send a high level command like system-power=query
         callback only tells you that the command was sent but not that it succsessfully did what you asked

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import type {API} from 'homebridge';
-import {OnkyoPlatform} from './onkyo-platform.js';
-import {PLATFORM_NAME} from './settings.js';
+import type { API } from 'homebridge';
+import { OnkyoPlatform } from './onkyo-platform.js';
+import { PLATFORM_NAME } from './settings.js';
 
 /**
  This method registers the platform with Homebridge
  */
 function registerPlatform(api: API) {
-	api.registerPlatform(PLATFORM_NAME, OnkyoPlatform);
+  api.registerPlatform(PLATFORM_NAME, OnkyoPlatform);
 }
 
 export default registerPlatform;

--- a/src/onkyo-platform.ts
+++ b/src/onkyo-platform.ts
@@ -1,80 +1,85 @@
 import {
-	type API,
-	type DynamicPlatformPlugin,
-	type Logger,
-	type PlatformAccessory,
+  type API,
+  type DynamicPlatformPlugin,
+  type Logger,
+  type PlatformAccessory,
 } from 'homebridge';
-import {Eiscp} from './eiscp/eiscp.js';
-import {OnkyoReceiver} from './onkyo-receiver.js';
-import {type Config} from './eiscp/config.js';
+import { Eiscp } from './eiscp/eiscp.js';
+import { OnkyoReceiver } from './onkyo-receiver.js';
+import { type Config } from './eiscp/config.js';
 
 export class OnkyoPlatform implements DynamicPlatformPlugin {
-	public readonly api: API;
-	public readonly config: Config;
-	public readonly log: Logger;
-	public readonly receiverAccessories: OnkyoReceiver[];
-	public readonly accessories: PlatformAccessory[];
-	public readonly existingAccessories: Map<string, PlatformAccessory>;
+  public readonly api: API;
+  public readonly config: Config;
+  public readonly log: Logger;
+  public readonly receiverAccessories: OnkyoReceiver[];
+  public readonly accessories: PlatformAccessory[];
+  public readonly existingAccessories: Map<string, PlatformAccessory>;
 
-	public readonly connections: Record<string, Eiscp>;
-	public numberReceivers?: number;
+  public readonly connections: Record<string, Eiscp>;
+  public numberReceivers?: number;
 
-	constructor(log: Logger, config: Config, api: API) {
-		this.api = api;
-		this.config = config;
-		this.log = log;
-		this.existingAccessories = new Map();
-		this.accessories = [];
-		this.connections = {};
-		this.receiverAccessories = [];
+  constructor(log: Logger, config: Config, api: API) {
+    this.api = api;
+    this.config = config;
+    this.log = log;
+    this.existingAccessories = new Map();
+    this.accessories = [];
+    this.connections = {};
+    this.receiverAccessories = [];
 
-		if (this.config === undefined) {
-			this.log.error('ERROR: your configuration is incorrect. Configuration changed with version 0.7.x');
-			throw new Error('ERROR: your configuration is incorrect. Configuration changed with version 0.7.x');
-		}
+    if (this.config === undefined) {
+      this.log.error(
+        'ERROR: your configuration is incorrect. Configuration changed with version 0.7.x'
+      );
+      throw new Error(
+        'ERROR: your configuration is incorrect. Configuration changed with version 0.7.x'
+      );
+    }
 
-		this.log.info('Finished initializing platform:', this.config.name);
+    this.log.info('Finished initializing platform:', this.config.name);
 
-		this.api.on('didFinishLaunching', () => {
-			this.log.debug('Executed didFinishLaunching callback');
-			this.createAccessories();
-		});
-	}
+    this.api.on('didFinishLaunching', () => {
+      this.log.debug('Executed didFinishLaunching callback');
+      this.createAccessories();
+    });
+  }
 
-	private createAccessories() {
-		this.numberReceivers = this.config.receivers.length;
-		this.log.debug('Creating %s receivers...', this.numberReceivers);
-		if (this.numberReceivers === 0)
-			return;
+  private createAccessories() {
+    this.numberReceivers = this.config.receivers.length;
+    this.log.debug('Creating %s receivers...', this.numberReceivers);
+    if (this.numberReceivers === 0) return;
 
-		for (const receiver of this.config.receivers) {
-			if (!Object.hasOwn(this.connections, receiver.ip_address)) {
-				this.log.debug(
-					'Creating new connection for ip %s',
-					receiver.ip_address,
-				);
-				this.connections[receiver.ip_address] = new Eiscp(this.log);
-				this.connections[receiver.ip_address].connect({
-					'host': receiver.ip_address,
-					'reconnect': true,
-					'model': receiver.model,
-				});
-			}
+    for (const receiver of this.config.receivers) {
+      if (!Object.hasOwn(this.connections, receiver.ip_address)) {
+        this.log.debug(
+          'Creating new connection for ip %s',
+          receiver.ip_address
+        );
+        this.connections[receiver.ip_address] = new Eiscp(this.log);
+        this.connections[receiver.ip_address].connect({
+          host: receiver.ip_address,
+          reconnect: true,
+          model: receiver.model,
+        });
+      }
 
-			const uuid = this.api.hap.uuid.generate('homebridge:homebridge-onkyo' + receiver.name);
-			const accessory =
-				this.existingAccessories.get(uuid)
-				?? new this.api.platformAccessory(
-					receiver.name,
-					uuid,
-					this.api.hap.Categories.AUDIO_RECEIVER,
-				);
-			const onkyoReceiver = new OnkyoReceiver(this, receiver, accessory);
-			this.receiverAccessories.push(onkyoReceiver);
-		}
-	}
+      const uuid = this.api.hap.uuid.generate(
+        'homebridge:homebridge-onkyo' + receiver.name
+      );
+      const accessory =
+        this.existingAccessories.get(uuid) ??
+        new this.api.platformAccessory(
+          receiver.name,
+          uuid,
+          this.api.hap.Categories.AUDIO_RECEIVER
+        );
+      const onkyoReceiver = new OnkyoReceiver(this, receiver, accessory);
+      this.receiverAccessories.push(onkyoReceiver);
+    }
+  }
 
-	configureAccessory(accessory: PlatformAccessory) {
-		this.existingAccessories.set(accessory.UUID, accessory);
-	}
+  configureAccessory(accessory: PlatformAccessory) {
+    this.existingAccessories.set(accessory.UUID, accessory);
+  }
 }

--- a/src/onkyo-receiver.ts
+++ b/src/onkyo-receiver.ts
@@ -1,1303 +1,1324 @@
-import {type CharacteristicValue, type PlatformAccessory, type Service} from 'homebridge';
+import {
+  type CharacteristicValue,
+  type PlatformAccessory,
+  type Service,
+} from 'homebridge';
 import pollingtoevent from 'polling-to-event';
-import {type OnkyoPlatform} from './onkyo-platform.js';
-import {type ReceiverConfig} from './receiver-config.js';
-import {type Eiscp} from './eiscp/eiscp.js';
-import {type ReceiverInputConfig} from './receiver-input-config.js';
+import { type OnkyoPlatform } from './onkyo-platform.js';
+import { type ReceiverConfig } from './receiver-config.js';
+import { type Eiscp } from './eiscp/eiscp.js';
+import { type ReceiverInputConfig } from './receiver-input-config.js';
 import eiscpCommandsData from './eiscp/eiscp-commands-data.js';
-import {PLUGIN_NAME} from './settings.js';
+import { PLUGIN_NAME } from './settings.js';
 
 type RxInput = {
-	'code': string;
-	'label': string;
+  code: string;
+  label: string;
 };
 
 type CommandInputs = {
-	'power': string;
-	'volume': string;
-	'input': string;
-	'muting': string;
+  power: string;
+  volume: string;
+  input: string;
+  muting: string;
 };
 
 type CommandZones = {
-	[zone: string]: CommandInputs;
-	'main': CommandInputs;
-	'zone2': CommandInputs;
+  [zone: string]: CommandInputs;
+  main: CommandInputs;
+  zone2: CommandInputs;
 };
 
 export class OnkyoReceiver {
-	private readonly platform: OnkyoPlatform;
-	private readonly eiscp: Eiscp;
-	private attemptCount: number;
-	private readonly receiver: ReceiverConfig;
-	private readonly cmdMap: CommandZones;
-	private readonly buttons: Map<number, string>;
-	private state: boolean;
-	private mState: boolean;
-	private vState: number;
-	private iState: number;
-	private readonly interval: number;
-	private readonly avrManufacturer: string;
-	private readonly avrSerial: string;
-	private readonly switchHandling: string;
-	private tvService?: Service;
-	private tvSpeakerService?: Service;
-	private rxInputs!: {'inputs': RxInput[]};
-	private dimmer?: Service;
-	private speed?: Service;
-	private readonly inputs?: ReceiverInputConfig[];
-	public accessory: PlatformAccessory;
-
-	constructor(
-		platform: OnkyoPlatform,
-		receiver: ReceiverConfig,
-		accessory: PlatformAccessory,
-	) {
-		this.platform = platform;
-		this.receiver = receiver;
-		this.accessory = accessory;
-		this.inputs = this.receiver.inputs;
-
-		this.platform.log.info('**************************************************************');
-		this.platform.log.info('  GitHub: https://github.com/jabrown93/homebridge-onkyo ');
-		this.platform.log.info('**************************************************************');
-		this.platform.log.info('start success...');
-		this.platform.log.debug('Debug mode enabled');
-
-		this.eiscp = platform.connections[receiver.ip_address];
-		this.attemptCount = 0;
-
-		this.platform.log.debug('name %s', this.receiver.name);
-		this.platform.log.debug('IP %s', this.receiver.ip_address);
-		this.platform.log.debug('Model %s', this.receiver.model);
-		this.receiver.zone = (this.receiver.zone ?? 'main').toLowerCase();
-		this.platform.log.debug('Zone %s', this.receiver.zone);
-		this.platform.log.debug('Input Mappings %s', this.inputs);
-
-		if (this.receiver.volume_type === undefined) {
-			this.platform.log.warn('WARNING: Your receiveruration is missing the parameter "volume_type". Assuming "none".');
-			this.receiver.volume_type = 'none';
-		}
-
-		if (this.receiver.filter_inputs === undefined) {
-			this.platform.log.warn('WARNING: Your receiveruration is missing the parameter "filter_inputs". Assuming "false".');
-			this.receiver.filter_inputs = false;
-		}
-
-		this.cmdMap = {
-			'main': {
-				'power': 'system-power',
-				'volume': 'master-volume',
-				'muting': 'audio-muting',
-				'input': 'input-selector',
-			},
-			'zone2': {
-				'power': 'power',
-				'volume': 'volume',
-				'muting': 'muting',
-				'input': 'selector',
-			},
-		};
-
-		this.receiver.poll_status_interval ??= '0';
-		this.platform.log.debug(
-			'poll_status_interval: %s',
-			this.receiver.poll_status_interval,
-		);
-		this.receiver.max_volume ??= 60;
-		this.platform.log.debug('max_volume: %s', this.receiver.max_volume);
-		this.receiver.map_volume_100 ??= true;
-		this.platform.log.debug('map_volume_100: %s', this.receiver.map_volume_100);
-		this.buttons = new Map();
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.REWIND,
-			'rew',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.FAST_FORWARD,
-			'ff',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.NEXT_TRACK,
-			'skip-f',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.PREVIOUS_TRACK,
-			'skip-r',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.ARROW_UP,
-			'up',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.ARROW_DOWN,
-			'down',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.ARROW_LEFT,
-			'left',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.ARROW_RIGHT,
-			'right',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.SELECT,
-			'enter',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.BACK,
-			'exit',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.EXIT,
-			'exit',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.PLAY_PAUSE,
-			'play',
-		);
-		this.buttons.set(
-			this.platform.api.hap.Characteristic.RemoteKey.INFORMATION,
-			'home',
-		);
-
-		this.state = false;
-		this.mState = false;
-		this.vState = 0;
-		this.iState = 0;
-		this.interval = Number(this.receiver.poll_status_interval);
-		this.avrManufacturer = 'Onkyo';
-		this.avrSerial = this.receiver.serial ?? this.receiver.ip_address;
-		this.platform.log.debug('avrSerial: %s', this.avrSerial);
-		this.switchHandling = 'check';
-		if (this.interval > 10 && this.interval < 100_000)
-			this.switchHandling = 'poll';
-
-		this.eiscp.on('debug', this.eventDebug.bind(this));
-		this.eiscp.on('error', this.eventError.bind(this));
-		this.eiscp.on('connect', this.eventConnect.bind(this));
-		this.eiscp.on('close', this.eventClose.bind(this));
-		this.eiscp.on(
-			this.cmdMap[this.receiver.zone].power,
-			this.eventSystemPower.bind(this),
-		);
-		this.eiscp.on(
-			this.cmdMap[this.receiver.zone].volume,
-			this.eventVolume.bind(this),
-		);
-		this.eiscp.on(
-			this.cmdMap[this.receiver.zone].muting,
-			this.eventAudioMuting.bind(this),
-		);
-		this.eiscp.on(
-			this.cmdMap[this.receiver.zone].input,
-			this.eventInput.bind(this),
-		);
-
-		this.setUp();
-	}
-
-	private setUp() {
-		this.createRxInput();
-		this.polling();
-		this.createAccessoryInformationService();
-		this.tvService = this.createTvService();
-		this.tvSpeakerService = this.createTvSpeakerService();
-		this.addSources(this.tvService);
-		if (this.receiver.volume_type !== undefined && this.receiver.volume_type !== '' && this.receiver.volume_type !== 'none') {
-			this.platform.log.debug(
-				'Creating %s service linked to TV for receiver %s',
-				this.receiver.volume_type,
-				this.receiver.name,
-			);
-			this.createVolumeType(this.tvService);
-		}
-
-		this.platform.api.publishExternalAccessories(PLUGIN_NAME, [this.accessory]);
-	}
-
-	private createRxInput() {
-		const data = eiscpCommandsData;
-		const inSets: string[] = [];
-		for (const set in data.modelsets) {
-			if (!Object.hasOwn(data.modelsets, set))
-				continue;
-
-			if (data.modelsets[set].some(model => model.includes(this.receiver.model))) {
-				this.platform.log.debug('Found modelset: %s', set);
-				inSets.push(set);
-			}
-		}
-
-		// Get list of commands from eiscpData
-		const eiscpData = data.commands.main.SLI.values;
-		// Create a JSON object for inputs from the eiscpData
-		const inputs: {'inputs': RxInput[]} = {
-			'inputs': [],
-		};
-		for (const exkey in eiscpData) {
-			if (!Object.hasOwn(eiscpData, exkey))
-				continue;
-
-			const name = eiscpData[exkey].name;
-			if (name === undefined)
-				continue;
-
-			let hold = name.toString();
-			if (hold.includes(','))
-				hold = hold.slice(0, hold.indexOf(','));
-
-			let newExkey = exkey;
-			if (exkey.includes('“') || exkey.includes('”')) {
-				newExkey = newExkey.replaceAll('“', '');
-				newExkey = newExkey.replaceAll('”', '');
-			}
-
-			if (
-				newExkey.includes('UP')
-				|| newExkey.includes('DOWN')
-				|| newExkey.includes('QSTN')
-			)
-				continue;
-
-			// Work around specific bug for “26”
-			if (newExkey === '“26”')
-				newExkey = '26';
-
-			if (!Object.hasOwn(eiscpData, newExkey) || !Object.hasOwn(eiscpData[newExkey], 'models'))
-				continue;
-
-			const set = eiscpData[newExkey].models;
-
-			if (inSets.includes(set)) {
-				const input: RxInput = {
-					'code': newExkey,
-					'label': hold,
-				};
-				inputs.inputs.push(input);
-			}
-		}
-
-		this.rxInputs = inputs;
-	}
-
-	/// ////////////////
-	// EVENT FUNCTIONS
-	/// ////////////////
-	private eventDebug(response) {
-		this.platform.log.debug('eventDebug: %s', response);
-	}
-
-	private eventError(response) {
-		this.platform.log.error('eventError: %s', response);
-	}
-
-	private eventConnect(response) {
-		this.platform.log.debug('eventConnect: %s', response);
-	}
-
-	private eventSystemPower(response: string) {
-		if (this.state !== (response === 'on'))
-			this.platform.log.info('Event - System Power changed: %s', response);
-
-		this.state = response === 'on';
-		this.platform.log.debug(
-			'eventSystemPower - message: %s, new state %s',
-			response,
-			this.state,
-		);
-		this.tvService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Active,
-			this.state,
-		);
-	}
-
-	private eventAudioMuting(response: string) {
-		this.mState = response === 'on';
-		this.platform.log.debug(
-			'eventAudioMuting - message: %s, new mState %s',
-			response,
-			this.mState,
-		);
-		this.tvSpeakerService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Mute,
-			this.mState,
-		);
-	}
-
-	private eventInput(response: string | string[] | undefined) {
-		if (response === undefined) {
-			// Then invalid Input chosen
-			this.platform.log.error('eventInput - ERROR - INVALID INPUT - Model does not support selected input.');
-		} else {
-			let input = JSON.stringify(response);
-			input = input.replaceAll(/["\[\]]+/gv, '');
-			if (input.includes(','))
-				input = input.slice(0, input.indexOf(','));
-
-			// Convert to iState input code
-			const index =
-				input === null
-					? -1
-					: this.rxInputs.inputs.findIndex(i => i.label === input);
-			if (this.iState !== index + 1)
-				this.platform.log.info('Event - Input changed: %s', input);
-
-			this.iState = index + 1;
-
-			this.platform.log.debug(
-				'eventInput - message: %s - new iState: %s - input: %s',
-				response,
-				this.iState,
-				input,
-			);
-		}
-
-		this.tvService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.ActiveIdentifier,
-			this.iState,
-		);
-	}
-
-	private eventVolume(response: number) {
-		if (this.receiver.map_volume_100) {
-			const volumeMultiplier = (this.receiver.max_volume ?? 1) / 100;
-			const newVolume = response / volumeMultiplier;
-			this.vState = Math.round(newVolume);
-			this.platform.log.debug(
-				'eventVolume - message: %s, new vState %s PERCENT',
-				response,
-				this.vState,
-			);
-		} else {
-			this.vState = response;
-			this.platform.log.debug(
-				'eventVolume - message: %s, new vState %s ACTUAL',
-				response,
-				this.vState,
-			);
-		}
-
-		this.tvSpeakerService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Volume,
-			this.vState,
-		);
-	}
-
-	private eventClose(response) {
-		this.platform.log.debug('eventClose: %s', response);
-	}
-
-	/// /////////////////////
-	// GET AND SET FUNCTIONS
-	/// /////////////////////
-	private setPowerState(powerOn: CharacteristicValue, context: string): void {
-		// if context is statuspoll, then we need to ensure that we do not set the actual value
-		if (context === 'statuspoll') {
-			this.platform.log.debug(
-				'setPowerState - polling mode, ignore, state: %s',
-				this.state,
-			);
-			return;
-		}
-
-		if (this.receiver.ip_address === '') {
-			this.platform.log.error('Ignoring request; No ip_address defined.');
-			throw new Error('No ip_address defined.');
-		}
-
-		this.attemptCount++;
-
-		this.state = powerOn as boolean;
-		if (!this.state) {
-			this.platform.log.debug(
-				'setPowerState - actual mode, power state: %s, switching to OFF',
-				this.state,
-			);
-			this.eiscp.command(
-				this.receiver.zone
-				+ '.'
-				+ this.cmdMap[this.receiver.zone].power
-				+ '=standby',
-				error => {
-					if (error === undefined)
-						return;
-
-					this.state = false;
-					this.platform.log.error(
-						'setPowerState - PWR OFF: ERROR - current state: %s',
-						this.state,
-					);
-				},
-			);
-			this.tvService?.updateCharacteristic(
-				this.platform.api.hap.Characteristic.Active,
-				this.state,
-			);
-			return;
-		}
-
-		this.platform.log.debug(
-			'setPowerState - actual mode, power state: %s, switching to ON',
-			this.state,
-		);
-		this.eiscp.command(
-			this.receiver.zone + '.' + this.cmdMap[this.receiver.zone].power + '=on',
-			error => {
-				if (error !== undefined) {
-					this.state = false;
-					this.platform.log.error(
-						'setPowerState - PWR ON: ERROR - current state: %s',
-						this.state,
-					);
-					this.tvService?.updateCharacteristic(
-						this.platform.api.hap.Characteristic.Active,
-						'statuspoll',
-					);
-					return;
-				}
-
-				// If the AVR has just been turned on, apply the default volume
-				this.platform.log.debug('Attempting to set the default volume to '
-					+ this.receiver.default_volume);
-				if (this.receiver.default_volume !== undefined && this.receiver.default_volume !== 0) {
-					this.platform.log.info('Setting default volume to ' + this.receiver.default_volume);
-					this.eiscp.command(
-						this.receiver.zone
-						+ '.'
-						+ this.cmdMap[this.receiver.zone].volume
-						+ ':'
-						+ this.receiver.default_volume,
-						volumeError => {
-							if (volumeError !== undefined) {
-								this.platform.log.error(
-									'Error while setting default volume: %s',
-									volumeError,
-								);
-							}
-						},
-					);
-				}
-
-				// If the AVR has just been turned on, apply the Input default
-				this.platform.log.debug('Attempting to set the default input selector to '
-					+ this.receiver.default_input);
-
-				// Handle default_input being either a custom label or manufacturer label
-				let label = this.receiver.default_input;
-				if (this.inputs) {
-					for (const input of this.inputs) {
-						if (input.input_name === this.receiver.default_input)
-							label = input.input_name;
-						else if (input.display_name === this.receiver.default_input)
-							label = input.display_name;
-					}
-				}
-
-				const index =
-					label === null
-						? -1
-						: this.rxInputs.inputs.findIndex(i => i.label === label);
-				this.iState = index + 1;
-
-				if (this.state && label !== undefined && label !== '') {
-					this.platform.log.info('Setting default input selector to ' + label);
-					this.eiscp.command(
-						this.receiver.zone
-						+ '.'
-						+ this.cmdMap[this.receiver.zone].input
-						+ '='
-						+ label,
-						inputError => {
-							if (inputError !== undefined) {
-								this.platform.log.error(
-									'Error while setting default input: %s',
-									inputError,
-								);
-							}
-						},
-					);
-				}
-			},
-		);
-
-		this.tvService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Active,
-			this.state,
-		);
-	}
-
-	private polling() {
-		// Status Polling
-		if (this.switchHandling !== 'poll')
-			return;
-
-		this.platform.log.debug('start long poller..');
-		// PWR Polling
-		const statusemitter = pollingtoevent(
-			done => {
-				this.platform.log.debug('start PWR polling..');
-				const isResponse = this.getPowerState('statuspoll');
-				done(null, isResponse, this.attemptCount);
-			},
-			{
-				'longpolling': true,
-				'interval': this.interval * 1000,
-				'longpollEventName': 'statuspoll',
-			},
-		);
-
-		statusemitter.on('statuspoll', (isOn: boolean) => {
-			this.state = isOn;
-			this.platform.log.debug(
-				'event - PWR status poller - new state: ',
-				this.state,
-			);
-		});
-		// Audio-Input Polling
-		const iStatusEmitter = pollingtoevent(
-			done => {
-				this.platform.log.debug('start INPUT polling..');
-				const response = this.getInputSource('i_statuspoll');
-				done(null, response, this.attemptCount);
-			},
-			{
-				'longpolling': true,
-				'interval': this.interval * 1000,
-				'longpollEventName': 'i_statuspoll',
-			},
-		);
-
-		iStatusEmitter.on('i_statuspoll', (data: number) => {
-			this.iState = data;
-			this.platform.log.debug(
-				'event - INPUT status poller - new iState: ',
-				this.iState,
-			);
-		});
-		// Audio-Muting Polling
-		const mStatusEmitter = pollingtoevent(
-			done => {
-				this.platform.log.debug('start MUTE polling..');
-				const isResponse = this.getMuteState('m_statuspoll');
-				done(null, isResponse, this.attemptCount);
-			},
-			{
-				'longpolling': true,
-				'interval': this.interval * 1000,
-				'longpollEventName': 'm_statuspoll',
-			},
-		);
-
-		mStatusEmitter.on('m_statuspoll', (isMuted: boolean) => {
-			this.mState = isMuted;
-			this.platform.log.debug(
-				'event - MUTE status poller - new mState: ',
-				this.mState,
-			);
-		});
-		// Volume Polling
-		const vStatusEmitter = pollingtoevent(
-			done => {
-				this.platform.log.debug('start VOLUME polling..');
-				const response = this.getVolumeState('v_statuspoll');
-				done(null, response, this.attemptCount);
-			},
-			{
-				'longpolling': true,
-				'interval': this.interval * 1000,
-				'longpollEventName': 'v_statuspoll',
-			},
-		);
-
-		vStatusEmitter.on('v_statuspoll', (data: number) => {
-			this.vState = data;
-			this.platform.log.debug(
-				'event - VOLUME status poller - new vState: ',
-				this.vState,
-			);
-		});
-	}
-
-	private getPowerState(context) {
-		// if context is statuspoll, then we need to request the actual value
-		if (
-			context !== 'statuspoll'
-			&& this.switchHandling === 'poll'
-		) {
-			this.platform.log.debug(
-				'getPowerState - polling mode, return state: ',
-				this.state,
-			);
-			return this.state;
-		}
-
-		if (this.receiver.ip_address === '') {
-			this.platform.log.error('Ignoring request; No ip_address defined.');
-			throw new Error('No ip_address defined.');
-		}
-
-		this.platform.log.debug(
-			'getPowerState - actual mode, return state: ',
-			this.state,
-		);
-		this.eiscp.command(
-			this.receiver.zone
-			+ '.'
-			+ this.cmdMap[this.receiver.zone].power
-			+ '=query',
-			error => {
-				if (error === undefined)
-					return;
-
-				this.state = false;
-				this.platform.log.debug(
-					'getPowerState - PWR QRY: ERROR - current state: %s',
-					this.state,
-				);
-			},
-		);
-		this.tvService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Active,
-			this.state,
-		);
-		return this.state;
-	}
-
-	private getVolumeState(context) {
-		// if context is v_statuspoll, then we need to request the actual value
-		if (
-			context !== 'v_statuspoll'
-			&& this.switchHandling === 'poll'
-		) {
-			this.platform.log.debug(
-				'getVolumeState - polling mode, return vState: ',
-				this.vState,
-			);
-			return this.vState;
-		}
-
-		if (this.receiver.ip_address === '') {
-			this.platform.log.error('Ignoring request; No ip_address defined.');
-			throw new Error('No ip_address defined.');
-		}
-
-		this.platform.log.debug(
-			'getVolumeState - actual mode, return vState: ',
-			this.vState,
-		);
-		this.eiscp.command(
-			this.receiver.zone
-			+ '.'
-			+ this.cmdMap[this.receiver.zone].volume
-			+ '=query',
-			error => {
-				if (error === undefined)
-					return;
-
-				this.vState = 0;
-				this.platform.log.debug(
-					'getVolumeState - VOLUME QRY: ERROR - current vState: %s',
-					this.vState,
-				);
-			},
-		);
-
-		this.tvSpeakerService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Volume,
-			this.vState,
-		);
-
-		return this.vState;
-	}
-
-	private setVolumeState(volumeLvl: CharacteristicValue, context) {
-		// if context is v_statuspoll, then we need to ensure this we do not set the actual value
-		if (context === 'v_statuspoll') {
-			this.platform.log.debug(
-				'setVolumeState - polling mode, ignore, vState: %s',
-				this.vState,
-			);
-			return;
-		}
-
-		if (this.receiver.ip_address === '') {
-			this.platform.log.error('Ignoring request; No ip_address defined.');
-			throw new Error('No ip_address defined.');
-		}
-
-		this.attemptCount++;
-		const volumeLevel = volumeLvl as number;
-
-		// Are we mapping volume to 100%?
-		if (this.receiver.map_volume_100) {
-			const volumeMultiplier = this.receiver.max_volume !== undefined && this.receiver.max_volume !== 0
-				? this.receiver.max_volume / 100
-				: 100;
-			const newVolume = volumeMultiplier * volumeLevel;
-			this.vState = Math.round(newVolume);
-			this.platform.log.debug(
-				'setVolumeState - actual mode, PERCENT, volume vState: %s',
-				this.vState,
-			);
-		} else if (volumeLevel > (this.receiver.max_volume ?? 100)) {
-			// Determine if max_volume threshold breached, if so set to max.
-			this.vState = this.receiver.max_volume ?? 100;
-			this.platform.log.debug(
-				'setVolumeState - VOLUME LEVEL of: %s exceeds max_volume: %s. Resetting to max.',
-				volumeLevel,
-				this.receiver.max_volume,
-			);
-		} else {
-			// Must be using actual volume number
-			this.vState = volumeLevel;
-			this.platform.log.debug(
-				'setVolumeState - actual mode, ACTUAL volume vState: %s',
-				this.vState,
-			);
-		}
-
-		this.eiscp.command(
-			this.receiver.zone
-			+ '.'
-			+ this.cmdMap[this.receiver.zone].volume
-			+ ':'
-			+ this.vState,
-			error => {
-				if (error === undefined)
-					return;
-
-				this.vState = 0;
-				this.platform.log.debug(
-					'setVolumeState - VOLUME : ERROR - current vState: %s',
-					this.vState,
-				);
-			},
-		);
-
-		this.tvSpeakerService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Volume,
-			this.vState,
-		);
-	}
-
-	private setVolumeRelative(volumeDirection, context) {
-		// if context is v_statuspoll, then we need to ensure this we do not set the actual value
-		if (context === 'v_statuspoll') {
-			this.platform.log.debug(
-				'setVolumeRelative - polling mode, ignore, vState: %s',
-				this.vState,
-			);
-			return;
-		}
-
-		if (this.receiver.ip_address === '') {
-			this.platform.log.error('Ignoring request; No ip_address defined.');
-			throw new Error('No ip_address defined.');
-		}
-
-		this.attemptCount++;
-
-		if (
-			volumeDirection
-			=== this.platform.api.hap.Characteristic.VolumeSelector.INCREMENT
-		) {
-			this.platform.log.debug('setVolumeRelative - VOLUME : level-up');
-			this.eiscp.command(
-				this.receiver.zone
-				+ '.'
-				+ this.cmdMap[this.receiver.zone].volume
-				+ ':level-up',
-				error => {
-					if (error === undefined)
-						return;
-
-					this.vState = 0;
-					this.platform.log.error(
-						'setVolumeRelative - VOLUME : ERROR - current vState: %s',
-						this.vState,
-					);
-				},
-			);
-		} else if (
-			volumeDirection
-			=== this.platform.api.hap.Characteristic.VolumeSelector.DECREMENT
-		) {
-			this.platform.log.debug('setVolumeRelative - VOLUME : level-down');
-			this.eiscp.command(
-				this.receiver.zone
-				+ '.'
-				+ this.cmdMap[this.receiver.zone].volume
-				+ ':level-down',
-				error => {
-					if (error === undefined)
-						return;
-
-					this.vState = 0;
-					this.platform.log.error(
-						'setVolumeRelative - VOLUME : ERROR - current vState: %s',
-						this.vState,
-					);
-				},
-			);
-		} else {
-			this.platform.log.error('setVolumeRelative - VOLUME : ERROR - unknown direction sent');
-		}
-
-		this.tvSpeakerService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Volume,
-			this.vState,
-		);
-	}
-
-	private getMuteState(context) {
-		// if context is m_statuspoll, then we need to request the actual value
-		if (
-			context !== 'm_statuspoll'
-			&& this.switchHandling === 'poll'
-		) {
-			this.platform.log.debug(
-				'getMuteState - polling mode, return mState: ',
-				this.mState,
-			);
-			return this.mState;
-		}
-
-		if (this.receiver.ip_address === '') {
-			this.platform.log.error('Ignoring request; No ip_address defined.');
-			throw new Error('No ip_address defined.');
-		}
-
-		this.platform.log.debug(
-			'getMuteState - actual mode, return mState: ',
-			this.mState,
-		);
-		this.eiscp.command(
-			this.receiver.zone
-			+ '.'
-			+ this.cmdMap[this.receiver.zone].muting
-			+ '=query',
-			error => {
-				if (error === undefined)
-					return;
-
-				this.mState = false;
-				this.platform.log.debug(
-					'getMuteState - MUTE QRY: ERROR - current mState: %s',
-					this.mState,
-				);
-			},
-		);
-
-		this.tvSpeakerService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Mute,
-			this.mState,
-		);
-
-		return this.mState;
-	}
-
-	private setMuteState(muteOn: CharacteristicValue, context: string) {
-		// if context is m_statuspoll, then we need to ensure this we do not set the actual value
-		if (context === 'm_statuspoll') {
-			this.platform.log.debug(
-				'setMuteState - polling mode, ignore, mState: %s',
-				this.mState,
-			);
-			return this.mState;
-		}
-
-		if (this.receiver.ip_address === '') {
-			this.platform.log.error('Ignoring request; No ip_address defined.');
-			throw new Error('No ip_address defined.');
-		}
-
-		this.attemptCount++;
-
-		this.mState = muteOn as boolean;
-		if (this.mState) {
-			this.platform.log.debug(
-				'setMuteState - actual mode, mute mState: %s, switching to ON',
-				this.mState,
-			);
-			this.eiscp.command(
-				this.receiver.zone
-				+ '.'
-				+ this.cmdMap[this.receiver.zone].muting
-				+ '=on',
-				error => {
-					if (error === undefined)
-						return;
-
-					this.mState = false;
-					this.platform.log.error(
-						'setMuteState - MUTE ON: ERROR - current mState: %s',
-						this.mState,
-					);
-				},
-			);
-		} else {
-			this.platform.log.debug(
-				'setMuteState - actual mode, mute mState: %s, switching to OFF',
-				this.mState,
-			);
-			this.eiscp.command(
-				this.receiver.zone
-				+ '.'
-				+ this.cmdMap[this.receiver.zone].muting
-				+ '=off',
-				error => {
-					if (error === undefined)
-						return;
-
-					this.mState = false;
-					this.platform.log.error(
-						'setMuteState - MUTE OFF: ERROR - current mState: %s',
-						this.mState,
-					);
-				},
-			);
-		}
-
-		this.tvSpeakerService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.Mute,
-			this.mState,
-		);
-		return this.mState;
-	}
-
-	private getInputSource(context: string) {
-		// if context is i_statuspoll, then we need to request the actual value
-		if (
-			context !== 'i_statuspoll'
-			&& this.switchHandling === 'poll'
-		) {
-			this.platform.log.debug(
-				'getInputState - polling mode, return iState: ',
-				this.iState,
-			);
-			return this.iState;
-		}
-
-		if (this.receiver.ip_address === '') {
-			this.platform.log.error('Ignoring request; No ip_address defined.');
-			throw new Error('No ip_address defined.');
-		}
-
-		this.platform.log.debug(
-			'getInputState - actual mode, return iState: ',
-			this.iState,
-		);
-		this.eiscp.command(
-			this.receiver.zone
-			+ '.'
-			+ this.cmdMap[this.receiver.zone].input
-			+ '=query',
-			error => {
-				if (error === undefined)
-					return;
-
-				this.iState = 1;
-				this.platform.log.error(
-					'getInputState - INPUT QRY: ERROR - current iState: %s',
-					this.iState,
-				);
-			},
-		);
-
-		this.tvService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.ActiveIdentifier,
-			this.iState,
-		);
-
-		return this.iState;
-	}
-
-	private setInputSource(source: CharacteristicValue, context) {
-		// if context is i_statuspoll, then we need to ensure this we do not set the actual value
-		if (context === 'i_statuspoll') {
-			this.platform.log.info(
-				'setInputState - polling mode, ignore, iState: %s',
-				this.iState,
-			);
-			return;
-		}
-
-		if (this.receiver.ip_address === '') {
-			this.platform.log.error('Ignoring request; No ip_address defined.');
-			throw new Error('No ip_address defined.');
-		}
-
-		this.attemptCount++;
-
-		this.iState = source as number;
-		const label = this.rxInputs.inputs[this.iState - 1].label;
-
-		this.platform.log.debug(
-			'setInputState - actual mode, ACTUAL input iState: %s - label: %s',
-			this.iState,
-			label,
-		);
-
-		this.eiscp.command(
-			this.receiver.zone
-			+ '.'
-			+ this.cmdMap[this.receiver.zone].input
-			+ ':'
-			+ label,
-			error => {
-				if (error !== undefined) {
-					this.platform.log.error(
-						'setInputState - INPUT : ERROR - current iState:%s - Source:%s',
-						this.iState,
-						(source as number).toString(),
-					);
-				}
-			},
-		);
-
-		this.tvService?.updateCharacteristic(
-			this.platform.api.hap.Characteristic.ActiveIdentifier,
-			this.iState,
-		);
-	}
-
-	private remoteKeyPress(remoteKey: CharacteristicValue) {
-		const button = remoteKey as number;
-		const press = this.buttons.get(button);
-		if (press === undefined) {
-			this.platform.log.error('Remote button %d not supported.', button);
-			return;
-		}
-
-		this.platform.log.debug('remoteKeyPress - INPUT: pressing key %s', press);
-		this.eiscp.command(this.receiver.zone + '.setup=' + press, error => {
-			if (error === undefined)
-				return;
-
-			this.iState = 1;
-			this.platform.log.error(
-				'remoteKeyPress - INPUT: ERROR pressing button %s',
-				press,
-			);
-		});
-	}
-
-	/// /////////////////////
-	// TV SERVICE FUNCTIONS
-	/// /////////////////////
-	private addSources(service: Service) {
-		// If input name mappings are provided, use them.
-		// Option to only receiver specified inputs with filter_inputs
-		this.platform.log.debug('Supported inputs', this.rxInputs.inputs);
-		if (this.receiver.filter_inputs && this.inputs) {
-			// Check the rxInputs.inputs items to see if each exists in this.inputs. Return new array of those that do.
-			this.rxInputs.inputs = this.rxInputs.inputs.filter(rxinput => this.inputs?.some(input => input.input_name === rxinput.label));
-		}
-
-		this.platform.log.debug('Inputs: %s', this.rxInputs.inputs);
-		// Create final array of inputs, using any labels defined in the receiver's inputs to override the default labels
-		return this.rxInputs.inputs.map((i, index: number) => {
-			const hapId = index + 1;
-			let inputName = i.label;
-			if (this.inputs) {
-				for (const input of this.inputs) {
-					if (input.input_name !== i.label)
-						continue;
-
-					this.platform.log.debug(
-						'Found input mapping for %s to %s ',
-						i.label,
-						input.display_name,
-					);
-					inputName = input.display_name ?? i.label;
-				}
-			}
-
-			return this.setupInput(i.code, inputName, hapId, service);
-		});
-	}
-
-	private setupInput(inputCode: string, name: string, hapId: number, television: Service) {
-		const normalizedName = name.replace('-', ' ');
-		const input = this.accessory.addService(
-			this.platform.api.hap.Service.InputSource,
-			`${this.receiver.name} ${normalizedName}`,
-			inputCode,
-		);
-		const inputSourceType =
-			this.platform.api.hap.Characteristic.InputSourceType.HDMI;
-
-		input
-			.setCharacteristic(this.platform.api.hap.Characteristic.Identifier, hapId)
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.ConfiguredName,
-				normalizedName,
-			)
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.IsConfigured,
-				this.platform.api.hap.Characteristic.IsConfigured.CONFIGURED,
-			)
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.InputSourceType,
-				inputSourceType,
-			);
-
-		input
-			.getCharacteristic(this.platform.api.hap.Characteristic.ConfiguredName)
-			.setProps({
-				'perms': [this.platform.api.hap.Perms.PAIRED_READ],
-			});
-
-		television.addLinkedService(input);
-		return input;
-	}
-
-	private createAccessoryInformationService() {
-		const informationService =
-			this.accessory.getService(this.platform.api.hap.Service.AccessoryInformation)
-			?? this.accessory.addService(this.platform.api.hap.Service.AccessoryInformation);
-
-		informationService
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.Manufacturer,
-				this.avrManufacturer,
-			)
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.Model,
-				this.receiver.model,
-			)
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.SerialNumber,
-				this.avrSerial,
-			)
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.FirmwareRevision,
-				'info.version',
-			)
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.Name,
-				this.receiver.name,
-			);
-
-		return informationService;
-	}
-
-	private createVolumeType(service: Service) {
-		if (this.receiver.volume_type === 'dimmer') {
-			this.dimmer = this.accessory.addService(
-				this.platform.api.hap.Service.Lightbulb,
-				this.receiver.name + ' Volume',
-				'dimmer',
-			);
-			this.dimmer
-				.getCharacteristic(this.platform.api.hap.Characteristic.On)
-			// Inverted logic taken from https://github.com/langovoi/homebridge-upnp
-				.onGet(() => !this.getMuteState(null))
-				.onSet(value => this.setMuteState(!(value as boolean), ''));
-			this.dimmer
-				.addCharacteristic(this.platform.api.hap.Characteristic.Brightness)
-				.onGet(this.getVolumeState.bind(this))
-				.onSet(this.setVolumeState.bind(this));
-
-			service.addLinkedService(this.dimmer);
-		} else if (this.receiver.volume_type === 'speed') {
-			this.speed = this.accessory.addService(
-				this.platform.api.hap.Service.Fan,
-				this.receiver.name + ' Volume',
-				'speed',
-			);
-			this.speed
-				.getCharacteristic(this.platform.api.hap.Characteristic.On)
-			// Inverted logic taken from https://github.com/langovoi/homebridge-upnp
-				.onGet(context => !this.getMuteState(context))
-				.onSet((value, context) => this.setMuteState(!(value as boolean), context as string));
-			this.speed
-				.addCharacteristic(this.platform.api.hap.Characteristic.RotationSpeed)
-				.onGet(this.getVolumeState.bind(this))
-				.onSet(this.setVolumeState.bind(this));
-
-			service.addLinkedService(this.speed);
-		}
-	}
-
-	private createTvService() {
-		this.platform.log.debug(
-			'Creating TV service for receiver %s',
-			this.receiver.name,
-		);
-		const tvService =
-			this.accessory.getService(this.platform.api.hap.Service.Television)
-			?? this.accessory.addService(
-				this.platform.api.hap.Service.Television,
-				this.receiver.name,
-			);
-
-		tvService
-			.getCharacteristic(this.platform.api.hap.Characteristic.ConfiguredName)
-			.setValue(this.receiver.name)
-			.setProps({
-				'perms': [this.platform.api.hap.Perms.PAIRED_READ],
-			});
-
-		tvService.setCharacteristic(
-			this.platform.api.hap.Characteristic.SleepDiscoveryMode,
-			this.platform.api.hap.Characteristic.SleepDiscoveryMode
-				.ALWAYS_DISCOVERABLE,
-		);
-
-		tvService
-			.getCharacteristic(this.platform.api.hap.Characteristic.Active)
-			.onGet(this.getPowerState.bind(this))
-			.onSet(this.setPowerState.bind(this));
-
-		tvService
-			.getCharacteristic(this.platform.api.hap.Characteristic.ActiveIdentifier)
-			.onSet(this.setInputSource.bind(this))
-			.onGet(this.getInputSource.bind(this));
-
-		tvService
-			.getCharacteristic(this.platform.api.hap.Characteristic.RemoteKey)
-			.onSet(this.remoteKeyPress.bind(this));
-
-		return tvService;
-	}
-
-	private createTvSpeakerService() {
-		this.platform.log.debug(
-			'Creating TV Speaker service for receiver `%s`',
-			this.receiver.name,
-		);
-		const tvSpeakerService =
-			this.accessory.getService(this.platform.api.hap.Service.TelevisionSpeaker)
-			?? this.accessory.addService(
-				this.platform.api.hap.Service.TelevisionSpeaker,
-				this.receiver.name + ' Volume',
-				'tvSpeakerService',
-			);
-		tvSpeakerService
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.Active,
-				this.platform.api.hap.Characteristic.Active.ACTIVE,
-			)
-			.setCharacteristic(
-				this.platform.api.hap.Characteristic.VolumeControlType,
-				this.platform.api.hap.Characteristic.VolumeControlType.ABSOLUTE,
-			);
-		tvSpeakerService
-			.getCharacteristic(this.platform.api.hap.Characteristic.VolumeSelector)
-			.onSet(this.setVolumeRelative.bind(this));
-		tvSpeakerService
-			.getCharacteristic(this.platform.api.hap.Characteristic.Mute)
-			.onGet(this.getMuteState.bind(this))
-			.onSet(this.setMuteState.bind(this));
-		tvSpeakerService
-			.addCharacteristic(this.platform.api.hap.Characteristic.Volume)
-			.onGet(this.getVolumeState.bind(this))
-			.onSet(this.setVolumeState.bind(this));
-
-		this.tvService?.addLinkedService(tvSpeakerService);
-		return tvSpeakerService;
-	}
+  private readonly platform: OnkyoPlatform;
+  private readonly eiscp: Eiscp;
+  private attemptCount: number;
+  private readonly receiver: ReceiverConfig;
+  private readonly cmdMap: CommandZones;
+  private readonly buttons: Map<number, string>;
+  private state: boolean;
+  private mState: boolean;
+  private vState: number;
+  private iState: number;
+  private readonly interval: number;
+  private readonly avrManufacturer: string;
+  private readonly avrSerial: string;
+  private readonly switchHandling: string;
+  private tvService?: Service;
+  private tvSpeakerService?: Service;
+  private rxInputs!: { inputs: RxInput[] };
+  private dimmer?: Service;
+  private speed?: Service;
+  private readonly inputs?: ReceiverInputConfig[];
+  public accessory: PlatformAccessory;
+
+  constructor(
+    platform: OnkyoPlatform,
+    receiver: ReceiverConfig,
+    accessory: PlatformAccessory
+  ) {
+    this.platform = platform;
+    this.receiver = receiver;
+    this.accessory = accessory;
+    this.inputs = this.receiver.inputs;
+
+    this.platform.log.info(
+      '**************************************************************'
+    );
+    this.platform.log.info(
+      '  GitHub: https://github.com/jabrown93/homebridge-onkyo '
+    );
+    this.platform.log.info(
+      '**************************************************************'
+    );
+    this.platform.log.info('start success...');
+    this.platform.log.debug('Debug mode enabled');
+
+    this.eiscp = platform.connections[receiver.ip_address];
+    this.attemptCount = 0;
+
+    this.platform.log.debug('name %s', this.receiver.name);
+    this.platform.log.debug('IP %s', this.receiver.ip_address);
+    this.platform.log.debug('Model %s', this.receiver.model);
+    this.receiver.zone = (this.receiver.zone ?? 'main').toLowerCase();
+    this.platform.log.debug('Zone %s', this.receiver.zone);
+    this.platform.log.debug('Input Mappings %s', this.inputs);
+
+    if (this.receiver.volume_type === undefined) {
+      this.platform.log.warn(
+        'WARNING: Your receiveruration is missing the parameter "volume_type". Assuming "none".'
+      );
+      this.receiver.volume_type = 'none';
+    }
+
+    if (this.receiver.filter_inputs === undefined) {
+      this.platform.log.warn(
+        'WARNING: Your receiveruration is missing the parameter "filter_inputs". Assuming "false".'
+      );
+      this.receiver.filter_inputs = false;
+    }
+
+    this.cmdMap = {
+      main: {
+        power: 'system-power',
+        volume: 'master-volume',
+        muting: 'audio-muting',
+        input: 'input-selector',
+      },
+      zone2: {
+        power: 'power',
+        volume: 'volume',
+        muting: 'muting',
+        input: 'selector',
+      },
+    };
+
+    this.receiver.poll_status_interval ??= '0';
+    this.platform.log.debug(
+      'poll_status_interval: %s',
+      this.receiver.poll_status_interval
+    );
+    this.receiver.max_volume ??= 60;
+    this.platform.log.debug('max_volume: %s', this.receiver.max_volume);
+    this.receiver.map_volume_100 ??= true;
+    this.platform.log.debug('map_volume_100: %s', this.receiver.map_volume_100);
+    this.buttons = new Map();
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.REWIND,
+      'rew'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.FAST_FORWARD,
+      'ff'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.NEXT_TRACK,
+      'skip-f'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.PREVIOUS_TRACK,
+      'skip-r'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.ARROW_UP,
+      'up'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.ARROW_DOWN,
+      'down'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.ARROW_LEFT,
+      'left'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.ARROW_RIGHT,
+      'right'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.SELECT,
+      'enter'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.BACK,
+      'exit'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.EXIT,
+      'exit'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.PLAY_PAUSE,
+      'play'
+    );
+    this.buttons.set(
+      this.platform.api.hap.Characteristic.RemoteKey.INFORMATION,
+      'home'
+    );
+
+    this.state = false;
+    this.mState = false;
+    this.vState = 0;
+    this.iState = 0;
+    this.interval = Number(this.receiver.poll_status_interval);
+    this.avrManufacturer = 'Onkyo';
+    this.avrSerial = this.receiver.serial ?? this.receiver.ip_address;
+    this.platform.log.debug('avrSerial: %s', this.avrSerial);
+    this.switchHandling = 'check';
+    if (this.interval > 10 && this.interval < 100_000)
+      this.switchHandling = 'poll';
+
+    this.eiscp.on('debug', this.eventDebug.bind(this));
+    this.eiscp.on('error', this.eventError.bind(this));
+    this.eiscp.on('connect', this.eventConnect.bind(this));
+    this.eiscp.on('close', this.eventClose.bind(this));
+    this.eiscp.on(
+      this.cmdMap[this.receiver.zone].power,
+      this.eventSystemPower.bind(this)
+    );
+    this.eiscp.on(
+      this.cmdMap[this.receiver.zone].volume,
+      this.eventVolume.bind(this)
+    );
+    this.eiscp.on(
+      this.cmdMap[this.receiver.zone].muting,
+      this.eventAudioMuting.bind(this)
+    );
+    this.eiscp.on(
+      this.cmdMap[this.receiver.zone].input,
+      this.eventInput.bind(this)
+    );
+
+    this.setUp();
+  }
+
+  private setUp() {
+    this.createRxInput();
+    this.polling();
+    this.createAccessoryInformationService();
+    this.tvService = this.createTvService();
+    this.tvSpeakerService = this.createTvSpeakerService();
+    this.addSources(this.tvService);
+    if (
+      this.receiver.volume_type !== undefined &&
+      this.receiver.volume_type !== '' &&
+      this.receiver.volume_type !== 'none'
+    ) {
+      this.platform.log.debug(
+        'Creating %s service linked to TV for receiver %s',
+        this.receiver.volume_type,
+        this.receiver.name
+      );
+      this.createVolumeType(this.tvService);
+    }
+
+    this.platform.api.publishExternalAccessories(PLUGIN_NAME, [this.accessory]);
+  }
+
+  private createRxInput() {
+    const data = eiscpCommandsData;
+    const inSets: string[] = [];
+    for (const set in data.modelsets) {
+      if (!Object.hasOwn(data.modelsets, set)) continue;
+
+      if (
+        data.modelsets[set].some(model => model.includes(this.receiver.model))
+      ) {
+        this.platform.log.debug('Found modelset: %s', set);
+        inSets.push(set);
+      }
+    }
+
+    // Get list of commands from eiscpData
+    const eiscpData = data.commands.main.SLI.values;
+    // Create a JSON object for inputs from the eiscpData
+    const inputs: { inputs: RxInput[] } = {
+      inputs: [],
+    };
+    for (const exkey in eiscpData) {
+      if (!Object.hasOwn(eiscpData, exkey)) continue;
+
+      const name = eiscpData[exkey].name;
+      if (name === undefined) continue;
+
+      let hold = name.toString();
+      if (hold.includes(',')) hold = hold.slice(0, hold.indexOf(','));
+
+      let newExkey = exkey;
+      if (exkey.includes('“') || exkey.includes('”')) {
+        newExkey = newExkey.replaceAll('“', '');
+        newExkey = newExkey.replaceAll('”', '');
+      }
+
+      if (
+        newExkey.includes('UP') ||
+        newExkey.includes('DOWN') ||
+        newExkey.includes('QSTN')
+      )
+        continue;
+
+      // Work around specific bug for “26”
+      if (newExkey === '“26”') newExkey = '26';
+
+      if (
+        !Object.hasOwn(eiscpData, newExkey) ||
+        !Object.hasOwn(eiscpData[newExkey], 'models')
+      )
+        continue;
+
+      const set = eiscpData[newExkey].models;
+
+      if (inSets.includes(set)) {
+        const input: RxInput = {
+          code: newExkey,
+          label: hold,
+        };
+        inputs.inputs.push(input);
+      }
+    }
+
+    this.rxInputs = inputs;
+  }
+
+  /// ////////////////
+  // EVENT FUNCTIONS
+  /// ////////////////
+  private eventDebug(response) {
+    this.platform.log.debug('eventDebug: %s', response);
+  }
+
+  private eventError(response) {
+    this.platform.log.error('eventError: %s', response);
+  }
+
+  private eventConnect(response) {
+    this.platform.log.debug('eventConnect: %s', response);
+  }
+
+  private eventSystemPower(response: string) {
+    if (this.state !== (response === 'on'))
+      this.platform.log.info('Event - System Power changed: %s', response);
+
+    this.state = response === 'on';
+    this.platform.log.debug(
+      'eventSystemPower - message: %s, new state %s',
+      response,
+      this.state
+    );
+    this.tvService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Active,
+      this.state
+    );
+  }
+
+  private eventAudioMuting(response: string) {
+    this.mState = response === 'on';
+    this.platform.log.debug(
+      'eventAudioMuting - message: %s, new mState %s',
+      response,
+      this.mState
+    );
+    this.tvSpeakerService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Mute,
+      this.mState
+    );
+  }
+
+  private eventInput(response: string | string[] | undefined) {
+    if (response === undefined) {
+      // Then invalid Input chosen
+      this.platform.log.error(
+        'eventInput - ERROR - INVALID INPUT - Model does not support selected input.'
+      );
+    } else {
+      let input = JSON.stringify(response);
+      input = input.replaceAll(/["\[\]]+/gv, '');
+      if (input.includes(',')) input = input.slice(0, input.indexOf(','));
+
+      // Convert to iState input code
+      const index =
+        input === null
+          ? -1
+          : this.rxInputs.inputs.findIndex(i => i.label === input);
+      if (this.iState !== index + 1)
+        this.platform.log.info('Event - Input changed: %s', input);
+
+      this.iState = index + 1;
+
+      this.platform.log.debug(
+        'eventInput - message: %s - new iState: %s - input: %s',
+        response,
+        this.iState,
+        input
+      );
+    }
+
+    this.tvService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.ActiveIdentifier,
+      this.iState
+    );
+  }
+
+  private eventVolume(response: number) {
+    if (this.receiver.map_volume_100) {
+      const volumeMultiplier = (this.receiver.max_volume ?? 1) / 100;
+      const newVolume = response / volumeMultiplier;
+      this.vState = Math.round(newVolume);
+      this.platform.log.debug(
+        'eventVolume - message: %s, new vState %s PERCENT',
+        response,
+        this.vState
+      );
+    } else {
+      this.vState = response;
+      this.platform.log.debug(
+        'eventVolume - message: %s, new vState %s ACTUAL',
+        response,
+        this.vState
+      );
+    }
+
+    this.tvSpeakerService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Volume,
+      this.vState
+    );
+  }
+
+  private eventClose(response) {
+    this.platform.log.debug('eventClose: %s', response);
+  }
+
+  /// /////////////////////
+  // GET AND SET FUNCTIONS
+  /// /////////////////////
+  private setPowerState(powerOn: CharacteristicValue, context: string): void {
+    // if context is statuspoll, then we need to ensure that we do not set the actual value
+    if (context === 'statuspoll') {
+      this.platform.log.debug(
+        'setPowerState - polling mode, ignore, state: %s',
+        this.state
+      );
+      return;
+    }
+
+    if (this.receiver.ip_address === '') {
+      this.platform.log.error('Ignoring request; No ip_address defined.');
+      throw new Error('No ip_address defined.');
+    }
+
+    this.attemptCount++;
+
+    this.state = powerOn as boolean;
+    if (!this.state) {
+      this.platform.log.debug(
+        'setPowerState - actual mode, power state: %s, switching to OFF',
+        this.state
+      );
+      this.eiscp.command(
+        this.receiver.zone +
+          '.' +
+          this.cmdMap[this.receiver.zone].power +
+          '=standby',
+        error => {
+          if (error === undefined) return;
+
+          this.state = false;
+          this.platform.log.error(
+            'setPowerState - PWR OFF: ERROR - current state: %s',
+            this.state
+          );
+        }
+      );
+      this.tvService?.updateCharacteristic(
+        this.platform.api.hap.Characteristic.Active,
+        this.state
+      );
+      return;
+    }
+
+    this.platform.log.debug(
+      'setPowerState - actual mode, power state: %s, switching to ON',
+      this.state
+    );
+    this.eiscp.command(
+      this.receiver.zone + '.' + this.cmdMap[this.receiver.zone].power + '=on',
+      error => {
+        if (error !== undefined) {
+          this.state = false;
+          this.platform.log.error(
+            'setPowerState - PWR ON: ERROR - current state: %s',
+            this.state
+          );
+          this.tvService?.updateCharacteristic(
+            this.platform.api.hap.Characteristic.Active,
+            'statuspoll'
+          );
+          return;
+        }
+
+        // If the AVR has just been turned on, apply the default volume
+        this.platform.log.debug(
+          'Attempting to set the default volume to ' +
+            this.receiver.default_volume
+        );
+        if (
+          this.receiver.default_volume !== undefined &&
+          this.receiver.default_volume !== 0
+        ) {
+          this.platform.log.info(
+            'Setting default volume to ' + this.receiver.default_volume
+          );
+          this.eiscp.command(
+            this.receiver.zone +
+              '.' +
+              this.cmdMap[this.receiver.zone].volume +
+              ':' +
+              this.receiver.default_volume,
+            volumeError => {
+              if (volumeError !== undefined) {
+                this.platform.log.error(
+                  'Error while setting default volume: %s',
+                  volumeError
+                );
+              }
+            }
+          );
+        }
+
+        // If the AVR has just been turned on, apply the Input default
+        this.platform.log.debug(
+          'Attempting to set the default input selector to ' +
+            this.receiver.default_input
+        );
+
+        // Handle default_input being either a custom label or manufacturer label
+        let label = this.receiver.default_input;
+        if (this.inputs) {
+          for (const input of this.inputs) {
+            if (input.input_name === this.receiver.default_input)
+              label = input.input_name;
+            else if (input.display_name === this.receiver.default_input)
+              label = input.display_name;
+          }
+        }
+
+        const index =
+          label === null
+            ? -1
+            : this.rxInputs.inputs.findIndex(i => i.label === label);
+        this.iState = index + 1;
+
+        if (this.state && label !== undefined && label !== '') {
+          this.platform.log.info('Setting default input selector to ' + label);
+          this.eiscp.command(
+            this.receiver.zone +
+              '.' +
+              this.cmdMap[this.receiver.zone].input +
+              '=' +
+              label,
+            inputError => {
+              if (inputError !== undefined) {
+                this.platform.log.error(
+                  'Error while setting default input: %s',
+                  inputError
+                );
+              }
+            }
+          );
+        }
+      }
+    );
+
+    this.tvService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Active,
+      this.state
+    );
+  }
+
+  private polling() {
+    // Status Polling
+    if (this.switchHandling !== 'poll') return;
+
+    this.platform.log.debug('start long poller..');
+    // PWR Polling
+    const statusemitter = pollingtoevent(
+      done => {
+        this.platform.log.debug('start PWR polling..');
+        const isResponse = this.getPowerState('statuspoll');
+        done(null, isResponse, this.attemptCount);
+      },
+      {
+        longpolling: true,
+        interval: this.interval * 1000,
+        longpollEventName: 'statuspoll',
+      }
+    );
+
+    statusemitter.on('statuspoll', (isOn: boolean) => {
+      this.state = isOn;
+      this.platform.log.debug(
+        'event - PWR status poller - new state: ',
+        this.state
+      );
+    });
+    // Audio-Input Polling
+    const iStatusEmitter = pollingtoevent(
+      done => {
+        this.platform.log.debug('start INPUT polling..');
+        const response = this.getInputSource('i_statuspoll');
+        done(null, response, this.attemptCount);
+      },
+      {
+        longpolling: true,
+        interval: this.interval * 1000,
+        longpollEventName: 'i_statuspoll',
+      }
+    );
+
+    iStatusEmitter.on('i_statuspoll', (data: number) => {
+      this.iState = data;
+      this.platform.log.debug(
+        'event - INPUT status poller - new iState: ',
+        this.iState
+      );
+    });
+    // Audio-Muting Polling
+    const mStatusEmitter = pollingtoevent(
+      done => {
+        this.platform.log.debug('start MUTE polling..');
+        const isResponse = this.getMuteState('m_statuspoll');
+        done(null, isResponse, this.attemptCount);
+      },
+      {
+        longpolling: true,
+        interval: this.interval * 1000,
+        longpollEventName: 'm_statuspoll',
+      }
+    );
+
+    mStatusEmitter.on('m_statuspoll', (isMuted: boolean) => {
+      this.mState = isMuted;
+      this.platform.log.debug(
+        'event - MUTE status poller - new mState: ',
+        this.mState
+      );
+    });
+    // Volume Polling
+    const vStatusEmitter = pollingtoevent(
+      done => {
+        this.platform.log.debug('start VOLUME polling..');
+        const response = this.getVolumeState('v_statuspoll');
+        done(null, response, this.attemptCount);
+      },
+      {
+        longpolling: true,
+        interval: this.interval * 1000,
+        longpollEventName: 'v_statuspoll',
+      }
+    );
+
+    vStatusEmitter.on('v_statuspoll', (data: number) => {
+      this.vState = data;
+      this.platform.log.debug(
+        'event - VOLUME status poller - new vState: ',
+        this.vState
+      );
+    });
+  }
+
+  private getPowerState(context) {
+    // if context is statuspoll, then we need to request the actual value
+    if (context !== 'statuspoll' && this.switchHandling === 'poll') {
+      this.platform.log.debug(
+        'getPowerState - polling mode, return state: ',
+        this.state
+      );
+      return this.state;
+    }
+
+    if (this.receiver.ip_address === '') {
+      this.platform.log.error('Ignoring request; No ip_address defined.');
+      throw new Error('No ip_address defined.');
+    }
+
+    this.platform.log.debug(
+      'getPowerState - actual mode, return state: ',
+      this.state
+    );
+    this.eiscp.command(
+      this.receiver.zone +
+        '.' +
+        this.cmdMap[this.receiver.zone].power +
+        '=query',
+      error => {
+        if (error === undefined) return;
+
+        this.state = false;
+        this.platform.log.debug(
+          'getPowerState - PWR QRY: ERROR - current state: %s',
+          this.state
+        );
+      }
+    );
+    this.tvService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Active,
+      this.state
+    );
+    return this.state;
+  }
+
+  private getVolumeState(context) {
+    // if context is v_statuspoll, then we need to request the actual value
+    if (context !== 'v_statuspoll' && this.switchHandling === 'poll') {
+      this.platform.log.debug(
+        'getVolumeState - polling mode, return vState: ',
+        this.vState
+      );
+      return this.vState;
+    }
+
+    if (this.receiver.ip_address === '') {
+      this.platform.log.error('Ignoring request; No ip_address defined.');
+      throw new Error('No ip_address defined.');
+    }
+
+    this.platform.log.debug(
+      'getVolumeState - actual mode, return vState: ',
+      this.vState
+    );
+    this.eiscp.command(
+      this.receiver.zone +
+        '.' +
+        this.cmdMap[this.receiver.zone].volume +
+        '=query',
+      error => {
+        if (error === undefined) return;
+
+        this.vState = 0;
+        this.platform.log.debug(
+          'getVolumeState - VOLUME QRY: ERROR - current vState: %s',
+          this.vState
+        );
+      }
+    );
+
+    this.tvSpeakerService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Volume,
+      this.vState
+    );
+
+    return this.vState;
+  }
+
+  private setVolumeState(volumeLvl: CharacteristicValue, context) {
+    // if context is v_statuspoll, then we need to ensure this we do not set the actual value
+    if (context === 'v_statuspoll') {
+      this.platform.log.debug(
+        'setVolumeState - polling mode, ignore, vState: %s',
+        this.vState
+      );
+      return;
+    }
+
+    if (this.receiver.ip_address === '') {
+      this.platform.log.error('Ignoring request; No ip_address defined.');
+      throw new Error('No ip_address defined.');
+    }
+
+    this.attemptCount++;
+    const volumeLevel = volumeLvl as number;
+
+    // Are we mapping volume to 100%?
+    if (this.receiver.map_volume_100) {
+      const volumeMultiplier =
+        this.receiver.max_volume !== undefined && this.receiver.max_volume !== 0
+          ? this.receiver.max_volume / 100
+          : 100;
+      const newVolume = volumeMultiplier * volumeLevel;
+      this.vState = Math.round(newVolume);
+      this.platform.log.debug(
+        'setVolumeState - actual mode, PERCENT, volume vState: %s',
+        this.vState
+      );
+    } else if (volumeLevel > (this.receiver.max_volume ?? 100)) {
+      // Determine if max_volume threshold breached, if so set to max.
+      this.vState = this.receiver.max_volume ?? 100;
+      this.platform.log.debug(
+        'setVolumeState - VOLUME LEVEL of: %s exceeds max_volume: %s. Resetting to max.',
+        volumeLevel,
+        this.receiver.max_volume
+      );
+    } else {
+      // Must be using actual volume number
+      this.vState = volumeLevel;
+      this.platform.log.debug(
+        'setVolumeState - actual mode, ACTUAL volume vState: %s',
+        this.vState
+      );
+    }
+
+    this.eiscp.command(
+      this.receiver.zone +
+        '.' +
+        this.cmdMap[this.receiver.zone].volume +
+        ':' +
+        this.vState,
+      error => {
+        if (error === undefined) return;
+
+        this.vState = 0;
+        this.platform.log.debug(
+          'setVolumeState - VOLUME : ERROR - current vState: %s',
+          this.vState
+        );
+      }
+    );
+
+    this.tvSpeakerService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Volume,
+      this.vState
+    );
+  }
+
+  private setVolumeRelative(volumeDirection, context) {
+    // if context is v_statuspoll, then we need to ensure this we do not set the actual value
+    if (context === 'v_statuspoll') {
+      this.platform.log.debug(
+        'setVolumeRelative - polling mode, ignore, vState: %s',
+        this.vState
+      );
+      return;
+    }
+
+    if (this.receiver.ip_address === '') {
+      this.platform.log.error('Ignoring request; No ip_address defined.');
+      throw new Error('No ip_address defined.');
+    }
+
+    this.attemptCount++;
+
+    if (
+      volumeDirection ===
+      this.platform.api.hap.Characteristic.VolumeSelector.INCREMENT
+    ) {
+      this.platform.log.debug('setVolumeRelative - VOLUME : level-up');
+      this.eiscp.command(
+        this.receiver.zone +
+          '.' +
+          this.cmdMap[this.receiver.zone].volume +
+          ':level-up',
+        error => {
+          if (error === undefined) return;
+
+          this.vState = 0;
+          this.platform.log.error(
+            'setVolumeRelative - VOLUME : ERROR - current vState: %s',
+            this.vState
+          );
+        }
+      );
+    } else if (
+      volumeDirection ===
+      this.platform.api.hap.Characteristic.VolumeSelector.DECREMENT
+    ) {
+      this.platform.log.debug('setVolumeRelative - VOLUME : level-down');
+      this.eiscp.command(
+        this.receiver.zone +
+          '.' +
+          this.cmdMap[this.receiver.zone].volume +
+          ':level-down',
+        error => {
+          if (error === undefined) return;
+
+          this.vState = 0;
+          this.platform.log.error(
+            'setVolumeRelative - VOLUME : ERROR - current vState: %s',
+            this.vState
+          );
+        }
+      );
+    } else {
+      this.platform.log.error(
+        'setVolumeRelative - VOLUME : ERROR - unknown direction sent'
+      );
+    }
+
+    this.tvSpeakerService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Volume,
+      this.vState
+    );
+  }
+
+  private getMuteState(context) {
+    // if context is m_statuspoll, then we need to request the actual value
+    if (context !== 'm_statuspoll' && this.switchHandling === 'poll') {
+      this.platform.log.debug(
+        'getMuteState - polling mode, return mState: ',
+        this.mState
+      );
+      return this.mState;
+    }
+
+    if (this.receiver.ip_address === '') {
+      this.platform.log.error('Ignoring request; No ip_address defined.');
+      throw new Error('No ip_address defined.');
+    }
+
+    this.platform.log.debug(
+      'getMuteState - actual mode, return mState: ',
+      this.mState
+    );
+    this.eiscp.command(
+      this.receiver.zone +
+        '.' +
+        this.cmdMap[this.receiver.zone].muting +
+        '=query',
+      error => {
+        if (error === undefined) return;
+
+        this.mState = false;
+        this.platform.log.debug(
+          'getMuteState - MUTE QRY: ERROR - current mState: %s',
+          this.mState
+        );
+      }
+    );
+
+    this.tvSpeakerService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Mute,
+      this.mState
+    );
+
+    return this.mState;
+  }
+
+  private setMuteState(muteOn: CharacteristicValue, context: string) {
+    // if context is m_statuspoll, then we need to ensure this we do not set the actual value
+    if (context === 'm_statuspoll') {
+      this.platform.log.debug(
+        'setMuteState - polling mode, ignore, mState: %s',
+        this.mState
+      );
+      return this.mState;
+    }
+
+    if (this.receiver.ip_address === '') {
+      this.platform.log.error('Ignoring request; No ip_address defined.');
+      throw new Error('No ip_address defined.');
+    }
+
+    this.attemptCount++;
+
+    this.mState = muteOn as boolean;
+    if (this.mState) {
+      this.platform.log.debug(
+        'setMuteState - actual mode, mute mState: %s, switching to ON',
+        this.mState
+      );
+      this.eiscp.command(
+        this.receiver.zone +
+          '.' +
+          this.cmdMap[this.receiver.zone].muting +
+          '=on',
+        error => {
+          if (error === undefined) return;
+
+          this.mState = false;
+          this.platform.log.error(
+            'setMuteState - MUTE ON: ERROR - current mState: %s',
+            this.mState
+          );
+        }
+      );
+    } else {
+      this.platform.log.debug(
+        'setMuteState - actual mode, mute mState: %s, switching to OFF',
+        this.mState
+      );
+      this.eiscp.command(
+        this.receiver.zone +
+          '.' +
+          this.cmdMap[this.receiver.zone].muting +
+          '=off',
+        error => {
+          if (error === undefined) return;
+
+          this.mState = false;
+          this.platform.log.error(
+            'setMuteState - MUTE OFF: ERROR - current mState: %s',
+            this.mState
+          );
+        }
+      );
+    }
+
+    this.tvSpeakerService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.Mute,
+      this.mState
+    );
+    return this.mState;
+  }
+
+  private getInputSource(context: string) {
+    // if context is i_statuspoll, then we need to request the actual value
+    if (context !== 'i_statuspoll' && this.switchHandling === 'poll') {
+      this.platform.log.debug(
+        'getInputState - polling mode, return iState: ',
+        this.iState
+      );
+      return this.iState;
+    }
+
+    if (this.receiver.ip_address === '') {
+      this.platform.log.error('Ignoring request; No ip_address defined.');
+      throw new Error('No ip_address defined.');
+    }
+
+    this.platform.log.debug(
+      'getInputState - actual mode, return iState: ',
+      this.iState
+    );
+    this.eiscp.command(
+      this.receiver.zone +
+        '.' +
+        this.cmdMap[this.receiver.zone].input +
+        '=query',
+      error => {
+        if (error === undefined) return;
+
+        this.iState = 1;
+        this.platform.log.error(
+          'getInputState - INPUT QRY: ERROR - current iState: %s',
+          this.iState
+        );
+      }
+    );
+
+    this.tvService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.ActiveIdentifier,
+      this.iState
+    );
+
+    return this.iState;
+  }
+
+  private setInputSource(source: CharacteristicValue, context) {
+    // if context is i_statuspoll, then we need to ensure this we do not set the actual value
+    if (context === 'i_statuspoll') {
+      this.platform.log.info(
+        'setInputState - polling mode, ignore, iState: %s',
+        this.iState
+      );
+      return;
+    }
+
+    if (this.receiver.ip_address === '') {
+      this.platform.log.error('Ignoring request; No ip_address defined.');
+      throw new Error('No ip_address defined.');
+    }
+
+    this.attemptCount++;
+
+    this.iState = source as number;
+    const label = this.rxInputs.inputs[this.iState - 1].label;
+
+    this.platform.log.debug(
+      'setInputState - actual mode, ACTUAL input iState: %s - label: %s',
+      this.iState,
+      label
+    );
+
+    this.eiscp.command(
+      this.receiver.zone +
+        '.' +
+        this.cmdMap[this.receiver.zone].input +
+        ':' +
+        label,
+      error => {
+        if (error !== undefined) {
+          this.platform.log.error(
+            'setInputState - INPUT : ERROR - current iState:%s - Source:%s',
+            this.iState,
+            (source as number).toString()
+          );
+        }
+      }
+    );
+
+    this.tvService?.updateCharacteristic(
+      this.platform.api.hap.Characteristic.ActiveIdentifier,
+      this.iState
+    );
+  }
+
+  private remoteKeyPress(remoteKey: CharacteristicValue) {
+    const button = remoteKey as number;
+    const press = this.buttons.get(button);
+    if (press === undefined) {
+      this.platform.log.error('Remote button %d not supported.', button);
+      return;
+    }
+
+    this.platform.log.debug('remoteKeyPress - INPUT: pressing key %s', press);
+    this.eiscp.command(this.receiver.zone + '.setup=' + press, error => {
+      if (error === undefined) return;
+
+      this.iState = 1;
+      this.platform.log.error(
+        'remoteKeyPress - INPUT: ERROR pressing button %s',
+        press
+      );
+    });
+  }
+
+  /// /////////////////////
+  // TV SERVICE FUNCTIONS
+  /// /////////////////////
+  private addSources(service: Service) {
+    // If input name mappings are provided, use them.
+    // Option to only receiver specified inputs with filter_inputs
+    this.platform.log.debug('Supported inputs', this.rxInputs.inputs);
+    if (this.receiver.filter_inputs && this.inputs) {
+      // Check the rxInputs.inputs items to see if each exists in this.inputs. Return new array of those that do.
+      this.rxInputs.inputs = this.rxInputs.inputs.filter(rxinput =>
+        this.inputs?.some(input => input.input_name === rxinput.label)
+      );
+    }
+
+    this.platform.log.debug('Inputs: %s', this.rxInputs.inputs);
+    // Create final array of inputs, using any labels defined in the receiver's inputs to override the default labels
+    return this.rxInputs.inputs.map((i, index: number) => {
+      const hapId = index + 1;
+      let inputName = i.label;
+      if (this.inputs) {
+        for (const input of this.inputs) {
+          if (input.input_name !== i.label) continue;
+
+          this.platform.log.debug(
+            'Found input mapping for %s to %s ',
+            i.label,
+            input.display_name
+          );
+          inputName = input.display_name ?? i.label;
+        }
+      }
+
+      return this.setupInput(i.code, inputName, hapId, service);
+    });
+  }
+
+  private setupInput(
+    inputCode: string,
+    name: string,
+    hapId: number,
+    television: Service
+  ) {
+    const normalizedName = name.replace('-', ' ');
+    const input = this.accessory.addService(
+      this.platform.api.hap.Service.InputSource,
+      `${this.receiver.name} ${normalizedName}`,
+      inputCode
+    );
+    const inputSourceType =
+      this.platform.api.hap.Characteristic.InputSourceType.HDMI;
+
+    input
+      .setCharacteristic(this.platform.api.hap.Characteristic.Identifier, hapId)
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.ConfiguredName,
+        normalizedName
+      )
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.IsConfigured,
+        this.platform.api.hap.Characteristic.IsConfigured.CONFIGURED
+      )
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.InputSourceType,
+        inputSourceType
+      );
+
+    input
+      .getCharacteristic(this.platform.api.hap.Characteristic.ConfiguredName)
+      .setProps({
+        perms: [this.platform.api.hap.Perms.PAIRED_READ],
+      });
+
+    television.addLinkedService(input);
+    return input;
+  }
+
+  private createAccessoryInformationService() {
+    const informationService =
+      this.accessory.getService(
+        this.platform.api.hap.Service.AccessoryInformation
+      ) ??
+      this.accessory.addService(
+        this.platform.api.hap.Service.AccessoryInformation
+      );
+
+    informationService
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.Manufacturer,
+        this.avrManufacturer
+      )
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.Model,
+        this.receiver.model
+      )
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.SerialNumber,
+        this.avrSerial
+      )
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.FirmwareRevision,
+        'info.version'
+      )
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.Name,
+        this.receiver.name
+      );
+
+    return informationService;
+  }
+
+  private createVolumeType(service: Service) {
+    if (this.receiver.volume_type === 'dimmer') {
+      this.dimmer = this.accessory.addService(
+        this.platform.api.hap.Service.Lightbulb,
+        this.receiver.name + ' Volume',
+        'dimmer'
+      );
+      this.dimmer
+        .getCharacteristic(this.platform.api.hap.Characteristic.On)
+        // Inverted logic taken from https://github.com/langovoi/homebridge-upnp
+        .onGet(() => !this.getMuteState(null))
+        .onSet(value => this.setMuteState(!(value as boolean), ''));
+      this.dimmer
+        .addCharacteristic(this.platform.api.hap.Characteristic.Brightness)
+        .onGet(this.getVolumeState.bind(this))
+        .onSet(this.setVolumeState.bind(this));
+
+      service.addLinkedService(this.dimmer);
+    } else if (this.receiver.volume_type === 'speed') {
+      this.speed = this.accessory.addService(
+        this.platform.api.hap.Service.Fan,
+        this.receiver.name + ' Volume',
+        'speed'
+      );
+      this.speed
+        .getCharacteristic(this.platform.api.hap.Characteristic.On)
+        // Inverted logic taken from https://github.com/langovoi/homebridge-upnp
+        .onGet(context => !this.getMuteState(context))
+        .onSet((value, context) =>
+          this.setMuteState(!(value as boolean), context as string)
+        );
+      this.speed
+        .addCharacteristic(this.platform.api.hap.Characteristic.RotationSpeed)
+        .onGet(this.getVolumeState.bind(this))
+        .onSet(this.setVolumeState.bind(this));
+
+      service.addLinkedService(this.speed);
+    }
+  }
+
+  private createTvService() {
+    this.platform.log.debug(
+      'Creating TV service for receiver %s',
+      this.receiver.name
+    );
+    const tvService =
+      this.accessory.getService(this.platform.api.hap.Service.Television) ??
+      this.accessory.addService(
+        this.platform.api.hap.Service.Television,
+        this.receiver.name
+      );
+
+    tvService
+      .getCharacteristic(this.platform.api.hap.Characteristic.ConfiguredName)
+      .setValue(this.receiver.name)
+      .setProps({
+        perms: [this.platform.api.hap.Perms.PAIRED_READ],
+      });
+
+    tvService.setCharacteristic(
+      this.platform.api.hap.Characteristic.SleepDiscoveryMode,
+      this.platform.api.hap.Characteristic.SleepDiscoveryMode
+        .ALWAYS_DISCOVERABLE
+    );
+
+    tvService
+      .getCharacteristic(this.platform.api.hap.Characteristic.Active)
+      .onGet(this.getPowerState.bind(this))
+      .onSet(this.setPowerState.bind(this));
+
+    tvService
+      .getCharacteristic(this.platform.api.hap.Characteristic.ActiveIdentifier)
+      .onSet(this.setInputSource.bind(this))
+      .onGet(this.getInputSource.bind(this));
+
+    tvService
+      .getCharacteristic(this.platform.api.hap.Characteristic.RemoteKey)
+      .onSet(this.remoteKeyPress.bind(this));
+
+    return tvService;
+  }
+
+  private createTvSpeakerService() {
+    this.platform.log.debug(
+      'Creating TV Speaker service for receiver `%s`',
+      this.receiver.name
+    );
+    const tvSpeakerService =
+      this.accessory.getService(
+        this.platform.api.hap.Service.TelevisionSpeaker
+      ) ??
+      this.accessory.addService(
+        this.platform.api.hap.Service.TelevisionSpeaker,
+        this.receiver.name + ' Volume',
+        'tvSpeakerService'
+      );
+    tvSpeakerService
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.Active,
+        this.platform.api.hap.Characteristic.Active.ACTIVE
+      )
+      .setCharacteristic(
+        this.platform.api.hap.Characteristic.VolumeControlType,
+        this.platform.api.hap.Characteristic.VolumeControlType.ABSOLUTE
+      );
+    tvSpeakerService
+      .getCharacteristic(this.platform.api.hap.Characteristic.VolumeSelector)
+      .onSet(this.setVolumeRelative.bind(this));
+    tvSpeakerService
+      .getCharacteristic(this.platform.api.hap.Characteristic.Mute)
+      .onGet(this.getMuteState.bind(this))
+      .onSet(this.setMuteState.bind(this));
+    tvSpeakerService
+      .addCharacteristic(this.platform.api.hap.Characteristic.Volume)
+      .onGet(this.getVolumeState.bind(this))
+      .onSet(this.setVolumeState.bind(this));
+
+    this.tvService?.addLinkedService(tvSpeakerService);
+    return tvSpeakerService;
+  }
 }

--- a/src/polling-to-event.d.ts
+++ b/src/polling-to-event.d.ts
@@ -3,28 +3,28 @@
  See node_modules/polling-to-event/index.js for the real (JS) implementation.
  */
 declare module 'polling-to-event' {
-	import type {EventEmitter} from 'node:events';
+  import type { EventEmitter } from 'node:events';
 
-	type PollingToEventOptions = {
-		'interval'?: number;
-		'eventName'?: string;
-		'longpollEventName'?: string;
-		'longpolling'?: boolean;
-	};
+  type PollingToEventOptions = {
+    interval?: number;
+    eventName?: string;
+    longpollEventName?: string;
+    longpolling?: boolean;
+  };
 
-	type PollingToEventEmitter = EventEmitter & {
-		pause(): void;
-		resume(): void;
-		clear(): void;
-	};
+  type PollingToEventEmitter = EventEmitter & {
+    pause(): void;
+    resume(): void;
+    clear(): void;
+  };
 
-	type PollDone = (error: unknown, ...parameters: unknown[]) => void;
-	type PollFunction = (done: PollDone) => void;
+  type PollDone = (error: unknown, ...parameters: unknown[]) => void;
+  type PollFunction = (done: PollDone) => void;
 
-	function pollingToEvent(
-		func: PollFunction,
-		options?: PollingToEventOptions,
-	): PollingToEventEmitter;
+  function pollingToEvent(
+    func: PollFunction,
+    options?: PollingToEventOptions
+  ): PollingToEventEmitter;
 
-	export default pollingToEvent;
+  export default pollingToEvent;
 }

--- a/src/receiver-config.ts
+++ b/src/receiver-config.ts
@@ -1,17 +1,17 @@
-import {type ReceiverInputConfig} from './receiver-input-config.js';
+import { type ReceiverInputConfig } from './receiver-input-config.js';
 
 export type ReceiverConfig = {
-	'default_input'?: string;
-	'default_volume'?: number;
-	'filter_inputs'?: boolean;
-	'inputs'?: ReceiverInputConfig[];
-	'ip_address': string;
-	'max_volume'?: number;
-	'map_volume_100'?: boolean;
-	'model': string;
-	'name': string;
-	'poll_status_interval'?: string;
-	'serial'?: string;
-	'volume_type'?: string;
-	'zone': string;
+  default_input?: string;
+  default_volume?: number;
+  filter_inputs?: boolean;
+  inputs?: ReceiverInputConfig[];
+  ip_address: string;
+  max_volume?: number;
+  map_volume_100?: boolean;
+  model: string;
+  name: string;
+  poll_status_interval?: string;
+  serial?: string;
+  volume_type?: string;
+  zone: string;
 };

--- a/src/receiver-input-config.ts
+++ b/src/receiver-input-config.ts
@@ -1,4 +1,4 @@
 export type ReceiverInputConfig = {
-	'input_name'?: string;
-	'display_name'?: string;
+  input_name?: string;
+  display_name?: string;
 };


### PR DESCRIPTION
## Migrate shared CI to `jabrown93/ci`

Repoints this repo off the reusable workflows in `jabrown93/.github` onto the versioned CI library `jabrown93/ci`. Part of the CI split; mirrors the validated `homebridge-philips-hue-sync-box#446`.

`node-build`, `codeql`, and `stale` are now **composite actions**, so their caller jobs own `runs-on`, the matrix, and the schedule. `npm-release` stays a **job-level reusable workflow**.

| File | Before | After |
|---|---|---|
| build | `node-build.yml` reusable | `actions/node-build`, matrix `['22.x','24.x']` owned here (`fail-fast:false`) |
| codeql | `codeql.yml` reusable | `actions/codeql` (javascript-typescript default; same job permissions) |
| stale | `stale.yml` reusable | `actions/stale` (schedule + permissions on the caller job) |
| release | `npm-release.yml@…#v1.5.0` | `npm-release.yml@63fdb13 # workflows-v1.0.0` (byte-identical file) |

### ⚠️ Behavior change to review
The `node-build` action runs **`npm run test`** — which the old reusable workflow did **not**. Because this repo was previously pinned at **v1.2.0**, it also now runs **`npm run prettier`** (v1.2.0's node-build ran neither prettier nor test). If `test`/`prettier` fail on this repo, that's a pre-existing gap the migration surfaces; the Build check on this PR is the gate.

All refs pinned to `jabrown93/ci@63fdb13`. `ci:` commit → no release bump. `dt-sbom.yml` is hand-inlined (not a consumer of the moved workflow) — untouched.
