### PR TITLE
chore(package): standardize npm publish metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@jabrown93/homebridge-onkyo",
+  "displayName": "Onkyo",
   "version": "1.5.4",
   "description": "Homebridge plugin for Onkyo Receivers",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "main": "dist/index.js",
   "prettier": "@jabrown93/dev-config/prettier",
   "scripts": {
-    "typecheck": "tsc --noEmit",
     "prettier": "prettier --check .",
     "format": "prettier --write .",
     "lint": "eslint src/**.ts",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,12 @@
   ],
   "type": "module",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "config.schema.json",
+    "CHANGELOG.md"
+  ],
   "prettier": "@jabrown93/dev-config/prettier",
   "scripts": {
     "prettier": "prettier --check .",


### PR DESCRIPTION
## Summary
- Removes the duplicate `typecheck` script (identical to `tsc`)
- Declares `types` (dist/index.d.ts, safe: dev-config's shared tsconfig sets `declaration: true`) and an explicit `files` publish whitelist (`dist`, `config.schema.json`, `CHANGELOG.md`) instead of relying on `.npmignore`
- Adds `displayName` for homebridge-config-ui-x

Part of a fleet-wide package.json cleanup pass across the homebridge-* plugins (onkyo, playstation, smartrent, philips-hue-sync-box).

## Test plan
- [x] `package.json` validated as well-formed JSON
- [ ] `npm run build` still emits `dist/eiscp/eiscp-commands.json` (confirmed via source: it's `import`ed with `resolveJsonModule`, so tsc already copies it)