### PR TITLE
ci: stop running the build twice per push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,15 @@
 name: Build and Lint
 on:
   push:
-    # Release branches get the post-merge run. renovate/** is required: the
-    # shared preset automerges by BRANCH (:automergeBranch), so those updates
-    # never open a PR and would otherwise reach the ruleset with zero status
-    # checks, which :automergeRequireAllStatusChecks blocks indefinitely.
-    branches: [main, beta, 'renovate/**']
+    # Release branches (main/beta/alpha/next, per release.yml) get the
+    # post-merge run. renovate/** is required because the shared preset
+    # automerges MOST updates by branch (:automergeBranch) rather than by PR,
+    # so those branches would reach the ruleset with zero status checks and
+    # :automergeRequireAllStatusChecks would block them indefinitely. Majors
+    # and security bumps still open a PR, covered by pull_request below.
+    branches: [main, beta, alpha, next, 'renovate/**']
   pull_request:
-    branches: [main, beta]
+    branches: [main, beta, alpha, next]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     branches: [main, beta, alpha, next]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,14 @@
 ---
 name: Build and Lint
 on:
-  - push
-  - pull_request
+  push:
+    # Release branches get the post-merge run. renovate/** is required: the
+    # shared preset automerges by BRANCH (:automergeBranch), so those updates
+    # never open a PR and would otherwise reach the ruleset with zero status
+    # checks, which :automergeRequireAllStatusChecks blocks indefinitely.
+    branches: [main, beta, 'renovate/**']
+  pull_request:
+    branches: [main, beta]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     branches: [main, beta, alpha, next]
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@
 name: 'CodeQL Advanced'
 on:
   push:
-    branches: ['main', 'beta']
+    branches: [main, beta]
   pull_request:
-    branches: ['main', 'beta']
+    branches: [main, beta]
   schedule:
     - cron: '25 22 * * 5'
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,9 @@ on:
     branches: ['main', 'beta']
   schedule:
     - cron: '25 22 * * 5'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   analyze:
     # codeql is now a composite action, so the caller owns runs-on and MUST


### PR DESCRIPTION
## What

Replaces the workflow's `on: [push, pull_request]` with branch-filtered triggers.

Written by an AI agent (Claude Code).

## Why

`on: [push, pull_request]` fires **twice for the same commit** on any same-repo PR branch — once for `push`, once for `pull_request`. Observed on a real PR:

```
pull_request  c8cd846  success
push          c8cd846  success
```

`concurrency` does not collapse them: the group key is `${{ github.event.pull_request.number || github.ref }}`, which resolves to the PR number for one event and `refs/heads/<branch>` for the other, so the two runs land in different groups. Every push to a PR branch costs double the CI minutes.

## Why `renovate/**` is kept on the push trigger

The obvious fix — `push: branches: [main]` — would break Renovate. The shared preset ([`jabrown93/.github`](https://github.com/jabrown93/.github/blob/main/renovate-config.json)) enables `:automergeBranch` and `:automergeRequireAllStatusChecks`, so most updates **never open a PR**; Renovate pushes `renovate/**` and fast-forwards the target branch once the branch is green. Without a `push` trigger on `renovate/**`, those branches report zero status checks and automerge blocks indefinitely. This mirrors the pattern already used in `homelab`, `AURA`, `CrossWatch` and `k8s-leader-elector`, whose workflows carry the same comment.

Release branches stay on the push trigger for the post-merge run.

## Effect

- PR branch push → 1 run (`pull_request`) instead of 2.
- Push to a release branch or `renovate/**` → 1 run, as before.
- Push to an unrelated local branch with no PR → no run (previously ran).

https://claude.ai/code/session_01Upjwen3GU16ZBfHgN1Baav
